### PR TITLE
cloudinary image management

### DIFF
--- a/backend/src/controllers/admin/content/admin_media_controller.js
+++ b/backend/src/controllers/admin/content/admin_media_controller.js
@@ -33,3 +33,16 @@ export async function uploadImages(req, res) {
     });
   }
 }
+
+export async function deleteImages(req, res) {
+  try {
+
+    const images = await mediaService.uploadImagesService(req.body.removedImages);
+
+    res.json({ images });
+  } catch (error) {
+    res.status(error.status || 500).json({
+      message: error.message || "Internal Server Error",
+    });
+  }
+}

--- a/backend/src/controllers/admin/content/admin_media_controller.js
+++ b/backend/src/controllers/admin/content/admin_media_controller.js
@@ -36,10 +36,12 @@ export async function uploadImages(req, res) {
 
 export async function deleteImages(req, res) {
   try {
-
-    const images = await mediaService.uploadImagesService(req.body.removedImages);
-
-    res.json({ images });
+    const { removedImages } = req.body;
+    if (!Array.isArray(removedImages) || removedImages.length === 0) {
+      return res.status(400).json({ message: "No images to delete" });
+    }
+    await mediaService.deleteImagesService(removedImages);
+    return res.sendStatus(204);
   } catch (error) {
     res.status(error.status || 500).json({
       message: error.message || "Internal Server Error",

--- a/backend/src/routes/admin_routes.js
+++ b/backend/src/routes/admin_routes.js
@@ -70,6 +70,7 @@ router.patch(
   requireFiles("Image"),
   adminMedia.uploadImages,
 );
+router.delete("/delete/images", adminOnly, adminMedia.deleteImages);
 
 // BANNERS
 router.post("/banners", adminOnly, adminBanners.addBanner);

--- a/backend/src/services/admin/content/admin_media_services.js
+++ b/backend/src/services/admin/content/admin_media_services.js
@@ -7,6 +7,18 @@ export async function attachImagesToBookService(bookId, images) {
   }
   const bookExists = await Book.exists({ _id: bookId });
   if (!bookExists) throw new Error("Book not found");
+  const existingImages = await BookImage.find({ book: bookId });
+  // filter removed images
+  const removedPublicIds = existingImages
+    .filter(
+      (img) =>
+        !images.some((incoming) => incoming.public_id === img.image?.public_id),
+    )
+    .map((img) => img.image?.public_id)
+    .filter(Boolean); // avoids undefined
+  if (removedPublicIds?.length) {
+    await deleteImagesService(removedPublicIds);
+  }
   await BookImage.deleteMany({ book: bookId });
   const insertedImages = await BookImage.insertMany(
     images.map((img, index) => ({

--- a/backend/src/services/admin/content/admin_media_services.js
+++ b/backend/src/services/admin/content/admin_media_services.js
@@ -96,7 +96,6 @@ export const deleteFromCloudinary = async (publicId) => {
 
   try {
     const result = await cloudinary.uploader.destroy(publicId);
-    console.log(`Deleted ${publicId}:`, result);
     return result;
   } catch (err) {
     console.error(`Cloudinary deletion error for ${publicId}:`, err.message);

--- a/backend/src/services/admin/content/admin_media_services.js
+++ b/backend/src/services/admin/content/admin_media_services.js
@@ -58,3 +58,10 @@ export async function uploadImagesService(files, type) {
     public_id: img.public_id,
   }));
 }
+
+export async function deleteImagesService(public_id) {
+  if (!public_id) {
+    throw new Error("No public ID provided.");
+  }
+  return await Promise.all(public_id.map((img) => deleteFromCloudinary(img)));
+}

--- a/backend/src/services/admin/content/admin_media_services.js
+++ b/backend/src/services/admin/content/admin_media_services.js
@@ -59,9 +59,24 @@ export async function uploadImagesService(files, type) {
   }));
 }
 
-export async function deleteImagesService(public_id) {
-  if (!public_id) {
-    throw new Error("No public ID provided.");
+export async function deleteImagesService(publicIds) {
+  if (!publicIds) {
+    throw new Error("No public ID(s) provided.");
   }
-  return await Promise.all(public_id.map((img) => deleteFromCloudinary(img)));
+
+  // normalize to array and prevent accidental bad calls
+  const ids = (Array.isArray(publicIds) ? publicIds : [publicIds]).filter(
+    Boolean,
+  );
+
+  return await Promise.all(
+    ids.map(async (id) => {
+      try {
+        return await deleteFromCloudinary(id);
+      } catch (err) {
+        console.error("Failed to delete:", id, err.message);
+        return null; // don't break entire batch
+      }
+    }),
+  );
 }

--- a/backend/src/services/admin/content/admin_media_services.js
+++ b/backend/src/services/admin/content/admin_media_services.js
@@ -75,7 +75,6 @@ export async function deleteImagesService(publicIds) {
   if (!publicIds) {
     throw new Error("No public ID(s) provided.");
   }
-
   // normalize to array and prevent accidental bad calls
   const ids = (Array.isArray(publicIds) ? publicIds : [publicIds]).filter(
     Boolean,
@@ -92,3 +91,15 @@ export async function deleteImagesService(publicIds) {
     }),
   );
 }
+export const deleteFromCloudinary = async (publicId) => {
+  if (!publicId) throw new Error("No public_id provided for deletion");
+
+  try {
+    const result = await cloudinary.uploader.destroy(publicId);
+    console.log(`Deleted ${publicId}:`, result);
+    return result;
+  } catch (err) {
+    console.error(`Cloudinary deletion error for ${publicId}:`, err.message);
+    throw err; // propagate error to your service
+  }
+};

--- a/backend/src/services/admin/core/admin_author_services.js
+++ b/backend/src/services/admin/core/admin_author_services.js
@@ -1,5 +1,5 @@
 import { Author, Book } from "../../../model/index.js";
-
+import { deleteImagesService } from "../../../services/admin/content/admin_media_services.js";
 export async function getAdminAuthorsService() {
   const authors = await Author.find().sort({ createdAt: -1 });
   return authors;
@@ -26,6 +26,8 @@ export async function addAuthorService(author) {
 
 export async function updateAuthorService(author) {
   const { authorCode, image, penName, bio } = author;
+  const authorImage = await Author.findOne({ authorCode: authorCode }, "image");
+  await deleteImagesService(authorImage.image?.public_id);
   const updateAuthor = await Author.findOneAndUpdate(
     { authorCode: authorCode },
     {

--- a/frontend/src/features/admin/authors/pages/components/AddAuthor.jsx
+++ b/frontend/src/features/admin/authors/pages/components/AddAuthor.jsx
@@ -18,7 +18,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { authorSchema } from "../../authorSchema";
 import { useEffect, useState } from "react";
 import { useAddAdminAuthor } from "../../hooks/admin_author_hooks";
-import { uploadImages } from "@/services/uploadImages";
+import { uploadImages } from "@/services/cloudinaryImages";
 import { cn } from "@/lib/utils";
 const AddAuthor = ({ open, setOpen }) => {
   const { mutate: addAuthor } = useAddAdminAuthor();

--- a/frontend/src/features/admin/authors/pages/components/EditAuthor.jsx
+++ b/frontend/src/features/admin/authors/pages/components/EditAuthor.jsx
@@ -19,7 +19,7 @@ import { cn } from "@/lib/utils";
 import { updateAuthorSchema } from "../../authorSchema";
 import { useUpdateAdminAuthor } from "../../hooks/admin_author_hooks";
 import { Spinner } from "@/components/ui/spinner";
-import { uploadImages } from "@/services/uploadImages";
+import { uploadImages } from "@/services/cloudinaryImages";
 const EditAuthor = ({ open, setOpen, author }) => {
   const { mutate: updateAuthor } = useUpdateAdminAuthor();
   const [isPending, setIsPending] = useState(false);

--- a/frontend/src/features/admin/books/bookSchema.js
+++ b/frontend/src/features/admin/books/bookSchema.js
@@ -53,6 +53,11 @@ export const updateBook = z.object({
       ]),
     )
     .optional(),
+  removedImages: z
+    .array(
+      z.string(), // old string URLs
+    )
+    .optional(),
   newImages: z
     .array(
       z

--- a/frontend/src/features/admin/books/pages/components/AddBook.jsx
+++ b/frontend/src/features/admin/books/pages/components/AddBook.jsx
@@ -34,7 +34,7 @@ import { useGetAdminAuthorsList } from "@/features/admin/authors/hooks/admin_aut
 import { addBook } from "../../bookSchema";
 import { useAddAdminBook } from "../../hooks/admin_books_hooks";
 import { useGetCategories } from "@/features/categories/hooks/category_hooks";
-import { uploadImages } from "@/services/uploadImages";
+import { uploadImages } from "@/services/cloudinaryImages";
 import BookCategories from "./BookCategories";
 import { Spinner } from "@/components/ui/spinner";
 

--- a/frontend/src/features/admin/books/pages/components/EditBook.jsx
+++ b/frontend/src/features/admin/books/pages/components/EditBook.jsx
@@ -34,7 +34,7 @@ import { useGetAdminAuthorsList } from "@/features/admin/authors/hooks/admin_aut
 import { updateBook } from "../../bookSchema";
 import { useUpdateAdminBooks } from "../../hooks/admin_books_hooks";
 import { useGetCategories } from "@/features/categories/hooks/category_hooks";
-import { uploadImages } from "@/services/uploadImages";
+import { uploadImages } from "@/services/cloudinaryImages";
 import BookCategories from "./BookCategories";
 import { Spinner } from "@/components/ui/spinner";
 

--- a/frontend/src/features/admin/books/pages/components/EditBook.jsx
+++ b/frontend/src/features/admin/books/pages/components/EditBook.jsx
@@ -34,7 +34,7 @@ import { useGetAdminAuthorsList } from "@/features/admin/authors/hooks/admin_aut
 import { updateBook } from "../../bookSchema";
 import { useUpdateAdminBooks } from "../../hooks/admin_books_hooks";
 import { useGetCategories } from "@/features/categories/hooks/category_hooks";
-import { uploadImages } from "@/services/cloudinaryImages";
+import { deleteImages, uploadImages } from "@/services/cloudinaryImages";
 import BookCategories from "./BookCategories";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -129,8 +129,11 @@ const EditBook = ({ book, open, setOpen }) => {
   const onSubmit = async (data) => {
     setIsPending(true);
     let uploadedUrls = [];
+    if (data.removedImages?.length > 0) {
+      await deleteImages(removedImages);
+    }
     if (data.newImages?.length > 0) {
-      const res = await uploadImages(data?.newImages, removedImages, "books");
+      const res = await uploadImages(data?.newImages, "books");
       uploadedUrls = res.images;
     }
     const categoryIds = data.categories;
@@ -157,7 +160,7 @@ const EditBook = ({ book, open, setOpen }) => {
   };
   const removeExistingImage = (url) => {
     const image = existingImages.filter((img) => img === url);
-    setValue("removedImages", [ ...removedImages, image[0].public_id ]);
+    setValue("removedImages", [...removedImages, image[0].public_id]);
     setValue(
       "existingImages",
       existingImages.filter((img) => img !== url),

--- a/frontend/src/features/admin/books/pages/components/EditBook.jsx
+++ b/frontend/src/features/admin/books/pages/components/EditBook.jsx
@@ -63,6 +63,7 @@ const EditBook = ({ book, open, setOpen }) => {
       categories: [],
       existingImages: [],
       newImages: [],
+      removedImages: [],
       bookCode: "",
     },
     resolver: zodResolver(updateBook),
@@ -71,6 +72,7 @@ const EditBook = ({ book, open, setOpen }) => {
   const categories = watch("categories");
   const existingImages = watch("existingImages");
   const newImages = watch("newImages");
+  const removedImages = watch("removedImages");
   // Populate form when book changes
   useEffect(() => {
     if (!book) return;
@@ -98,6 +100,7 @@ const EditBook = ({ book, open, setOpen }) => {
       price: book.price || 0,
       categories: book.categories?.map((c) => c._id) || [],
       existingImages: normalizedImages,
+      removedImages: [],
       newImages: [],
       bookCode: book.bookCode || "",
     });
@@ -127,7 +130,7 @@ const EditBook = ({ book, open, setOpen }) => {
     setIsPending(true);
     let uploadedUrls = [];
     if (data.newImages?.length > 0) {
-      const res = await uploadImages(data?.newImages, "books");
+      const res = await uploadImages(data?.newImages, removedImages, "books");
       uploadedUrls = res.images;
     }
     const categoryIds = data.categories;
@@ -153,6 +156,8 @@ const EditBook = ({ book, open, setOpen }) => {
     });
   };
   const removeExistingImage = (url) => {
+    const image = existingImages.filter((img) => img === url);
+    setValue("removedImages", [ ...removedImages, image[0].public_id ]);
     setValue(
       "existingImages",
       existingImages.filter((img) => img !== url),

--- a/frontend/src/services/cloudinaryImages.js
+++ b/frontend/src/services/cloudinaryImages.js
@@ -23,10 +23,7 @@ export const uploadImages = async (files, type = "general") => {
 export const deleteImages = async (removedImages) => {
   if (!removedImages) throw new Error("No public ID provided");
 
-  const formData = new FormData();
-  formData.append("removedImages", JSON.stringify(removedImages));
-
-  const res = await api.delete("/admin/upload/images", formData);
-
-  return res.data;
+  return await api.delete("/admin/delete/images", {
+    data: { removedImages },
+  });
 };

--- a/frontend/src/services/cloudinaryImages.js
+++ b/frontend/src/services/cloudinaryImages.js
@@ -1,5 +1,9 @@
 import api from "./axios";
-export const uploadImages = async (files, removedImages = [], type = "general") => {
+export const uploadImages = async (
+  files,
+  removedImages = [],
+  type = "general",
+) => {
   if (!files) throw new Error("No files provided");
 
   const fileArray = Array.isArray(files) ? files : [files];
@@ -18,6 +22,16 @@ export const uploadImages = async (files, removedImages = [], type = "general") 
       "Content-Type": "multipart/form-data",
     },
   });
+
+  return res.data;
+};
+export const deleteImages = async (removedImages) => {
+  if (!removedImages) throw new Error("No public ID provided");
+
+  const formData = new FormData();
+  formData.append("removedImages", JSON.stringify(removedImages));
+
+  const res = await api.delete("/admin/upload/images", formData);
 
   return res.data;
 };

--- a/frontend/src/services/cloudinaryImages.js
+++ b/frontend/src/services/cloudinaryImages.js
@@ -1,9 +1,5 @@
 import api from "./axios";
-export const uploadImages = async (
-  files,
-  removedImages = [],
-  type = "general",
-) => {
+export const uploadImages = async (files, type = "general") => {
   if (!files) throw new Error("No files provided");
 
   const fileArray = Array.isArray(files) ? files : [files];
@@ -15,7 +11,6 @@ export const uploadImages = async (
 
   // Optional: add type/folder info
   formData.append("type", type);
-  formData.append("removedImages", JSON.stringify(removedImages));
 
   const res = await api.patch("/admin/upload/images", formData, {
     headers: {

--- a/frontend/src/services/uploadImages.js
+++ b/frontend/src/services/uploadImages.js
@@ -1,5 +1,5 @@
 import api from "./axios";
-export const uploadImages = async (files, type = "general") => {
+export const uploadImages = async (files, removedImages = [], type = "general") => {
   if (!files) throw new Error("No files provided");
 
   const fileArray = Array.isArray(files) ? files : [files];
@@ -11,6 +11,7 @@ export const uploadImages = async (files, type = "general") => {
 
   // Optional: add type/folder info
   formData.append("type", type);
+  formData.append("removedImages", JSON.stringify(removedImages));
 
   const res = await api.patch("/admin/upload/images", formData, {
     headers: {


### PR DESCRIPTION
I refactored existing uploadImage logic
 - renamed uploadImage to cloudinaryImages since it does not only contain uploadImages helper but also the newly added deleteImages helper
 - added deleteImages controller and service
  - implemented to updateAdminBook and updateAdminAuthor services to first delete existing images from cloudinary before replacing the images in the database, this to avoid asset isolation in cloudinary