### PR TITLE
feat(admin-orders): implement AdminOrders page with data table and full order columns

### DIFF
--- a/backend/src/controllers/admin/commerce/admin_orders_controller.js
+++ b/backend/src/controllers/admin/commerce/admin_orders_controller.js
@@ -1,5 +1,15 @@
 import * as adminOrderService from "../../../services/admin/commerce/admin_order_services.js";
 
+export async function getAdminOrders(req, res) {
+  try {
+    const orders = await adminOrderService.getAdminOrdersService();
+    res.status(200).json(orders);
+  } catch (error) {
+    res
+      .status(error.status || 500)
+      .json({ message: error.message || "Internal Server Error" });
+  }
+}
 export async function updateOrder(req, res) {
   try {
     const id = req.params.id;

--- a/backend/src/routes/admin_routes.js
+++ b/backend/src/routes/admin_routes.js
@@ -43,6 +43,7 @@ router.patch(
 router.get("/customers", adminOnly, adminCustomers.getCustomers);
 
 // ORDERS
+router.get("/orders", adminOnly, adminOrders.getAdminOrders)
 router.put("/orders/:id", adminOnly, adminOrders.updateOrder);
 
 // HOMEPAGESECTION

--- a/backend/src/services/admin/commerce/admin_order_services.js
+++ b/backend/src/services/admin/commerce/admin_order_services.js
@@ -1,5 +1,13 @@
 import { Order } from "../../../model/index.js";
 
+export async function getAdminOrdersService() {
+  const orders = await Order.find()
+    .populate({ path: "items.book", model: "Book", select: "title price images" })
+    .populate("customer", "name customerCode phone")
+    .populate("payment")
+    .sort({ updatedAt: 1 });
+  return orders;
+}
 export async function updateOrderService(order) {
   const { id, status } = order;
   const updateOrder = await Order.findOneAndUpdate(

--- a/backend/src/services/admin/commerce/admin_order_services.js
+++ b/backend/src/services/admin/commerce/admin_order_services.js
@@ -2,7 +2,19 @@ import { Order } from "../../../model/index.js";
 
 export async function getAdminOrdersService() {
   const orders = await Order.find()
-    .populate({ path: "items.book", model: "Book", select: "title price images" })
+    .populate({
+      path: "items.book",
+      model: "Book",
+      select: "title price",
+      populate: [
+        {
+          path: "images",
+          select: "image",
+          match: { type: "cover" },
+          perDocumentLimit: 1,
+        },
+      ],
+    })
     .populate("customer", "name customerCode phone")
     .populate("payment")
     .sort({ updatedAt: 1 });

--- a/frontend/src/components/ui/collapsible.jsx
+++ b/frontend/src/components/ui/collapsible.jsx
@@ -1,0 +1,21 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}) {
+  return (<CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />);
+}
+
+function CollapsibleContent({
+  ...props
+}) {
+  return (<CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />);
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/frontend/src/features/admin/components/DataTable.jsx
+++ b/frontend/src/features/admin/components/DataTable.jsx
@@ -43,7 +43,7 @@ const DataTable = ({ data, columns }) => {
   return (
     <>
       <TableFilter table={table} />
-      <div className="flex flex-col h-full rounded-2xl border bg-background overflow-x-auto">
+      <div className="flex flex-col h-full rounded-2xl border bg-background  overflow-x-auto">
         <div className="flex-1 overflow-auto">
           <Table className="min-w-full table-fixed">
             <TableHeader className="sticky top-0 bg-background z-10">
@@ -58,6 +58,11 @@ const DataTable = ({ data, columns }) => {
                         header.column.columnDef.header,
                         header.getContext(),
                       )}
+                      <div
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        className="absolute right-0 top-0 h-full w-1 cursor-col-resize"
+                      />
                     </TableHead>
                   ))}
                 </TableRow>
@@ -66,11 +71,13 @@ const DataTable = ({ data, columns }) => {
             <TableBody>
               {rowModel.rows.length ? (
                 rowModel.rows.map((row) => (
-                  <TableRow key={row.id}>
+                  <TableRow key={row.id} className="align-top">
                     {row.getVisibleCells().map((cell) => (
                       <TableCell
                         key={cell.id}
-                        className={cell.column.columnDef.meta?.className}>
+                        className={`align-top whitespace-normal break-words ${
+                          cell.column.columnDef.meta?.className
+                        }`}>
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),

--- a/frontend/src/features/admin/orders/api/admin_orders.js
+++ b/frontend/src/features/admin/orders/api/admin_orders.js
@@ -1,0 +1,1 @@
+import api from "@/services/axios";

--- a/frontend/src/features/admin/orders/api/admin_orders.js
+++ b/frontend/src/features/admin/orders/api/admin_orders.js
@@ -1,1 +1,6 @@
 import api from "@/services/axios";
+
+export const getAdminOrdersRequest = async () => {
+  const res = await api.get("/admin/orders");
+  return res.data;
+};

--- a/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
+++ b/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
@@ -1,0 +1,1 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";

--- a/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
+++ b/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
@@ -1,1 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAdminOrdersRequest } from "../api/admin_orders";
+
+export const useGetAdminOrders = () => {
+  return useQuery({
+    queryKey: ["orders"],
+    queryFn: () => getAdminOrdersRequest(),
+    staleTime: 1000 * 60 * 2,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/frontend/src/features/admin/orders/pages/AdminOrders.jsx
+++ b/frontend/src/features/admin/orders/pages/AdminOrders.jsx
@@ -1,7 +1,14 @@
+import DataTable from "../../components/DataTable";
+import OrdersTableColumns from "./components/OrdersTableColumns";
+import { useGetAdminOrders } from "../hooks/admin_order_hooks";
 const AdminOrders = () => {
+  const { data } = useGetAdminOrders();
+  const columns = OrdersTableColumns();
   return (
-    <div>AdminOrders</div>
-  )
-}
+    <div className="flex flex-col flex-1 p-4 overflow-auto min-w-0">
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+};
 
-export default AdminOrders
+export default AdminOrders;

--- a/frontend/src/features/admin/orders/pages/components/OrdersTable.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrdersTable.jsx
@@ -1,7 +1,0 @@
-const OrdersTable = () => {
-  return (
-    <div>OrdersTable</div>
-  )
-}
-
-export default OrdersTable

--- a/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
@@ -1,7 +1,159 @@
-const OrdersTableColumns = () => {
-  return (
-    <div>OrdersTableColumns</div>
-  )
-}
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MoreHorizontal } from "lucide-react";
 
-export default OrdersTableColumns
+const OrdersTableColumns = () => [
+  // Order Code
+  {
+    header: "Order Code",
+    accessorKey: "orderCode",
+    meta: { className: "w-[90px] text-center" },
+    cell: ({ getValue }) => (
+      <span className="font-mono text-xs block text-center">{getValue()}</span>
+    ),
+  },
+
+  // Customer
+  {
+    header: "Customer",
+    accessorKey: "customer",
+    meta: { className: "w-[150px] text-center" },
+    cell: ({ row }) => {
+      const { customerCode, name } = row.original.customer;
+      return (
+        <div className="flex flex-col items-center text-sm">
+          <span className="font-mono text-xs text-muted-foreground">
+            {customerCode}
+          </span>
+          <span className="font-medium break-words">{name}</span>
+        </div>
+      );
+    },
+  },
+
+  // Items
+  {
+    header: "Items",
+    accessorKey: "items",
+    meta: { className: "w-[280px]" },
+    cell: ({ row }) => {
+      const items = row.original.items;
+      const visibleItems = items.slice(0, 2);
+      const remaining = items.length - 2;
+
+      return (
+        <div className="space-y-1">
+          {visibleItems.map((item, i) => (
+            <div key={i} className="flex gap-2 text-xs items-center">
+              <img
+                src={item.book?.images?.[0]?.image?.url}
+                alt={item.book?.title}
+                className="w-8 h-8 rounded object-cover"
+              />
+              <div className="flex flex-col flex-1">
+                <span className="font-medium break-words">
+                  {item.book?.title}
+                </span>
+                <div className="flex justify-between text-muted-foreground text-xs">
+                  <span>₱{item.book?.price.toFixed(2)}</span>
+                  <span>x{item.quantity}</span>
+                  <span className="font-medium text-foreground">
+                    ₱{(item.book?.price * item.quantity).toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+          {remaining > 0 && (
+            <span className="text-xs text-muted-foreground">
+              +{remaining} more items
+            </span>
+          )}
+        </div>
+      );
+    },
+  },
+
+  // Shipping Address
+  {
+    header: "Shipping Address",
+    accessorKey: "shippingAddress",
+    meta: { className: "w-[180px] text-center" },
+    cell: ({ row }) => {
+      const { street, city, zipCode, postalCode, country } =
+        row.original.shippingAddress;
+      return (
+        <div className="text-xs leading-tight break-words text-center">
+          {street}, {city}, {postalCode || zipCode}, {country}
+        </div>
+      );
+    },
+  },
+
+  // Status
+  {
+    header: "Status",
+    accessorKey: "status",
+    meta: { className: "w-[90px] text-center" },
+    cell: ({ getValue }) => {
+      const status = getValue();
+      const variantMap = {
+        pending: "secondary",
+        processing: "default",
+        shipped: "outline",
+        delivered: "success",
+        cancelled: "destructive",
+      };
+      return (
+        <Badge variant={variantMap[status] || "secondary"}>{status}</Badge>
+      );
+    },
+  },
+
+  // Payment
+  {
+    header: "Payment",
+    accessorKey: "payment.method",
+    meta: { className: "w-[70px] text-center" },
+    cell: ({ getValue }) => (
+      <span className="text-xs font-medium uppercase text-center">
+        {getValue()}
+      </span>
+    ),
+  },
+
+  // Actions (centered dropdown)
+  {
+    header: "Actions",
+    id: "actions",
+    meta: { className: "w-[60px] text-center" },
+    cell: ({ row }) => {
+      const order = row.original;
+      return (
+        <div className="flex justify-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="icon" variant="ghost">
+                <MoreHorizontal className="w-4 h-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center">
+              <DropdownMenuItem>View</DropdownMenuItem>
+              <DropdownMenuItem>Update</DropdownMenuItem>
+              <DropdownMenuItem className="text-red-500">
+                Cancel
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      );
+    },
+  },
+];
+export default OrdersTableColumns;

--- a/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
@@ -1,0 +1,7 @@
+const OrdersTableColumns = () => {
+  return (
+    <div>OrdersTableColumns</div>
+  )
+}
+
+export default OrdersTableColumns


### PR DESCRIPTION
This PR implements the `AdminOrders` page for managing orders in the admin panel. It replaces the placeholder component with a fully functional data table.
### Changes
- Added `OrdersTableColumns` with detailed columns:
  - **Order Code** – displayed in monospace for easy reference
  - **Customer** – shows customer code and name
  - **Items** – previews up to 2 items per order with image, title, price, and quantity; indicates additional items
  - **Shipping Address** – formatted street, city, postal/zip code, country
  - **Status** – badges for order status (`pending`, `processing`, `shipped`, `delivered`, `cancelled`)
  - **Payment** – displays payment method
  - **Actions** – dropdown menu with View, Update, and Cancel options
- `AdminOrders` page now fetches orders using `useGetAdminOrders` hook and renders the data table
- Refactored from placeholder component to full functional page
- Implemented Show/Hide Columns and Search

### Notes
- This is part of the admin panel order management feature.
- UI components use `Badge`, `Button`, and `DropdownMenu` from the design system.