### PR TITLE
feat(orders): implement admin Order Details page with API integration and status tracking

### DIFF
--- a/backend/src/constants/constant_values.js
+++ b/backend/src/constants/constant_values.js
@@ -24,6 +24,7 @@ export const ORDER_STATUSES = {
   PENDING: "pending",
   PAID: "paid",
   SHIPPED: "shipped",
+  OUT_FOR_DELIVERY: "out_for_delivery",
   DELIVERED: "delivered",
   CANCELLED: "cancelled",
   FAILED: "payment failed",

--- a/backend/src/controllers/admin/commerce/admin_orders_controller.js
+++ b/backend/src/controllers/admin/commerce/admin_orders_controller.js
@@ -21,3 +21,14 @@ export async function updateOrder(req, res) {
     res.status(500).json({ message: "Internal Server Error" });
   }
 }
+export async function getOrderDetail(req, res) {
+  try {
+    const orderCode = req.params.id;
+    const order = await orderService.getOrderDetailService(orderCode);
+    res.status(200).json(order);
+  } catch (error) {
+    res
+      .status(error.status || 500)
+      .json({ message: error.message || "Internal Server Error." });
+  }
+}

--- a/backend/src/controllers/admin/commerce/admin_orders_controller.js
+++ b/backend/src/controllers/admin/commerce/admin_orders_controller.js
@@ -24,7 +24,7 @@ export async function updateOrder(req, res) {
 export async function getOrderDetail(req, res) {
   try {
     const orderCode = req.params.id;
-    const order = await orderService.getOrderDetailService(orderCode);
+    const order = await adminOrderService.getOrderDetailService(orderCode);
     res.status(200).json(order);
   } catch (error) {
     res

--- a/backend/src/model/commerce/Order.js
+++ b/backend/src/model/commerce/Order.js
@@ -30,7 +30,7 @@ const orderSchema = new Schema(
     shippingAddress: {
       street: String,
       city: String,
-      postalCode: String,
+      zipCode: String,
       country: String,
     },
     //

--- a/backend/src/routes/admin_routes.js
+++ b/backend/src/routes/admin_routes.js
@@ -43,9 +43,9 @@ router.patch(
 router.get("/customers", adminOnly, adminCustomers.getCustomers);
 
 // ORDERS
-router.get("/orders", adminOnly, adminOrders.getAdminOrders)
+router.get("/orders", adminOnly, adminOrders.getAdminOrders);
 router.put("/orders/:id", adminOnly, adminOrders.updateOrder);
-
+router.get("/order/detail/:id", adminOnly, adminOrders.getOrderDetail);
 // HOMEPAGESECTION
 router.post(
   "/homepagesection/add",

--- a/backend/src/services/admin/commerce/admin_order_services.js
+++ b/backend/src/services/admin/commerce/admin_order_services.js
@@ -29,3 +29,23 @@ export async function updateOrderService(order) {
   );
   return updateOrder;
 }
+
+export async function getOrderDetailService(orderCode) {
+  const order = await Order.findOne({ orderCode: orderCode })
+    .populate({
+      path: "items.book",
+      model: "Book",
+      select: "title price",
+      populate: [
+        {
+          path: "images",
+          select: "image",
+          match: { type: "cover" },
+          perDocumentLimit: 1,
+        },
+      ],
+    })
+    .populate("customer", "name customerCode phone")
+    .populate("payment");
+  return order;
+}

--- a/frontend/src/app/Router.jsx
+++ b/frontend/src/app/Router.jsx
@@ -33,6 +33,7 @@ import AdminBooks from "@/features/admin/books/pages/AdminBooks";
 import AdminAuthors from "@/features/admin/authors/pages/AdminAuthors";
 import AdminCategories from "@/features/admin/categories/pages/AdminCategories";
 import AdminOrders from "@/features/admin/orders/pages/AdminOrders";
+import OrderDetails from "@/features/admin/orders/pages/components/OrderDetails";
 export default function AppRouter() {
   return (
     <Routes>
@@ -120,6 +121,14 @@ export default function AppRouter() {
           element={
             <RouteGuard>
               <AdminOrders />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/admin/order/detail/:id"
+          element={
+            <RouteGuard>
+              <OrderDetails />
             </RouteGuard>
           }
         />

--- a/frontend/src/features/admin/orders/api/admin_orders.js
+++ b/frontend/src/features/admin/orders/api/admin_orders.js
@@ -4,3 +4,7 @@ export const getAdminOrdersRequest = async () => {
   const res = await api.get("/admin/orders");
   return res.data;
 };
+export const getAdminOrderDetailRequest = async (orderCode) => {
+  const res = await api.get(`/admin/order/detail/${orderCode}`);
+  return res.data;
+};

--- a/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
+++ b/frontend/src/features/admin/orders/hooks/admin_order_hooks.js
@@ -1,5 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getAdminOrdersRequest } from "../api/admin_orders";
+import {
+  getAdminOrderDetailRequest,
+  getAdminOrdersRequest,
+} from "../api/admin_orders";
 
 export const useGetAdminOrders = () => {
   return useQuery({
@@ -7,5 +10,11 @@ export const useGetAdminOrders = () => {
     queryFn: () => getAdminOrdersRequest(),
     staleTime: 1000 * 60 * 2,
     refetchOnWindowFocus: false,
+  });
+};
+export const useGetAdminOrderDetail = (code) => {
+  return useQuery({
+    queryKey: ["orders", code],
+    queryFn: () => getAdminOrderDetailRequest(code),
   });
 };

--- a/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
@@ -1,0 +1,7 @@
+const OrderDetails = () => {
+  return (
+    <div>OrderDetails</div>
+  )
+}
+
+export default OrderDetails

--- a/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
@@ -2,16 +2,65 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { CheckCircle, Truck, Package, Clipboard } from "lucide-react";
-
-const steps = [
-  { label: "Processing", icon: CheckCircle, completed: true },
-  { label: "Shipped", icon: Truck, completed: true },
-  { label: "Out for Delivery", icon: Package, completed: false },
-  { label: "Delivered", icon: Clipboard, completed: false },
-];
+import { CheckCircle, Truck, Package, Clipboard, Package2 } from "lucide-react";
+import { useGetAdminOrderDetail } from "../../hooks/admin_order_hooks";
+import { useParams } from "react-router-dom";
 
 const OrderDetails = () => {
+  const { id } = useParams();
+  const { data: order, isPending } = useGetAdminOrderDetail(id);
+
+  // ORDER STATUS TRACKER stuff
+  const isCancelled = order?.status === "cancelled";
+  const steps = [
+    { key: "pending", label: "Pending", icon: CheckCircle },
+    { key: "paid", label: "Preparing", icon: Package2 },
+    { key: "shipped", label: "Shipped", icon: Truck },
+    {
+      key: "out_for_delivery",
+      label: "Out for Delivery",
+      icon: Package,
+      completed: false,
+    },
+    { key: "delivered", label: "Delivered", icon: Clipboard },
+  ];
+  const currentIndex = steps.findIndex((s) => s.key === order?.status);
+  const progress = () => {
+    const index = steps.findIndex((s) => s.key === order?.status);
+    if (index === -1 || order?.status === "cancelled") return 0;
+    // progress is based on step completion (e.g., step 1 of 4 => 25%)
+    return ((index + 1) / steps.length) * 100;
+  };
+  // FORMATTERS
+  const formatDate = (dateString) => {
+    if (!dateString) return;
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "2-digit",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true, // Optional: use 12-hour clock
+    }).format(date);
+  };
+  const formatPhone = (phoneNumber) => {
+    if (!phoneNumber) return;
+    // Remove all non-numeric characters
+    const cleaned = ("" + phoneNumber).replace(/\D/g, "");
+    let match = null;
+    cleaned.length == 11
+      ? (match = cleaned.match(/^(\d{3})(\d{4})(\d{4})$/))
+      : (match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/));
+
+    if (match) {
+      return `(${match[1]}) ${match[2]}-${match[3]}`;
+    }
+    return null;
+  };
+  // ---------------------------------------
+  const customer = order?.customer;
+  const address = order?.shippingAddress;
   return (
     <div className="p-6 space-y-6 overflow-auto">
       {/* Top Section */}
@@ -21,25 +70,43 @@ const OrderDetails = () => {
           <CardHeader>
             <CardTitle>Order ORD-12345</CardTitle>
             <p className="text-sm text-muted-foreground">
-              Placed on 2025-04-15
+              Placed on {formatDate(order?.createdAt)}
             </p>
           </CardHeader>
           <CardContent className="space-y-4">
             <div>
               <p className="font-semibold">Customer Information</p>
-              <p className="text-sm text-muted-foreground">Alice Johnson</p>
-              <p className="text-sm text-muted-foreground">alice@example.com</p>
+              <p className="text-sm text-muted-foreground">{customer?.name}</p>
               <p className="text-sm text-muted-foreground">
-                123 Main St, Anytown
+                +{formatPhone(customer?.phone)}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {address?.street}, {address?.city}, {address?.zipCode},
+                {address?.country}
               </p>
             </div>
 
-            <Card className="p-4 flex items-center justify-between">
+            <Card className="p-4 flex justify-between">
               <div>
                 <p className="font-medium">Payment Method</p>
-                <p className="text-sm text-muted-foreground">
-                  Visa ending in **** 1234
+                <p className="text-sm text-muted-foreground uppercase">
+                  {order?.payment?.method}
                 </p>
+                {order?.payment?.transactionId ? (
+                  <>
+                    <p className="font-medium">Transaction Id</p>
+                    <p className="text-sm text-muted-foreground">
+                      {order?.payment?.transactionId}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="font-medium">Order Id</p>
+                    <p className="text-sm text-muted-foreground">
+                      {order?._id}
+                    </p>
+                  </>
+                )}
               </div>
             </Card>
           </CardContent>
@@ -53,16 +120,12 @@ const OrderDetails = () => {
           <CardContent className="space-y-2">
             <div className="flex justify-between">
               <span>Subtotal</span>
-              <span>$101.97</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Shipping</span>
-              <span>$10.00</span>
+              <span>₱{order?.totalAmount.toFixed(2)}</span>
             </div>
             <Separator />
             <div className="flex justify-between font-semibold">
               <span>Total</span>
-              <span>$111.97</span>
+              <span>₱{order?.totalAmount.toFixed(2)}</span>
             </div>
           </CardContent>
         </Card>
@@ -77,11 +140,19 @@ const OrderDetails = () => {
           <div className="flex items-center justify-between">
             {steps.map((step, index) => {
               const Icon = step.icon;
+              const completed = !isCancelled && index <= currentIndex;
+
               return (
-                <div key={index} className="flex flex-col items-center flex-1">
+                <div
+                  key={step.key}
+                  className="flex flex-col items-center flex-1">
                   <div
                     className={`rounded-full p-3 ${
-                      step.completed ? "bg-green-500 text-white" : "bg-muted"
+                      isCancelled
+                        ? "bg-red-500 text-white"
+                        : completed
+                          ? "success"
+                          : "bg-muted"
                     }`}>
                     <Icon className="w-5 h-5" />
                   </div>
@@ -93,14 +164,32 @@ const OrderDetails = () => {
 
           {/* Progress bar */}
           <div className="h-2 bg-muted rounded-full mt-4 overflow-hidden">
-            <div className="h-full bg-black w-1/2" />
+            <div
+              className="h-full bg-black transition-all"
+              style={{ width: `${progress()}%` }}
+            />
           </div>
 
           <div className="mt-3">
-            <Badge>Shipped</Badge>
-            <span className="text-sm text-muted-foreground ml-2">
-              on December 23, 2024
-            </span>
+            {order?.status == "paid" ? (
+              <span className="text-sm text-muted-foreground ml-2">
+                Preparing your order.
+              </span>
+            ) : order?.status === "cancelled" ? (
+              <>
+                <Badge variant="destructive">Cancelled</Badge>
+                <span className="text-sm text-muted-foreground ml-2">
+                  on {formatDate(order?.updatedAt)}
+                </span>
+              </>
+            ) : (
+              <>
+                <Badge>Shipped</Badge>
+                <span className="text-sm text-muted-foreground ml-2">
+                  on {formatDate(order?.updatedAt)}
+                </span>
+              </>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -111,22 +200,25 @@ const OrderDetails = () => {
           <CardTitle>Order Items</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {[
-            { name: "Wireless Headphones", qty: 2, price: 25.99 },
-            { name: "Bluetooth Speaker", qty: 1, price: 49.99 },
-          ].map((item, i) => (
+          {order?.items?.map((item) => (
             <div
-              key={i}
+              key={item?._id}
               className="flex items-center justify-between border-b pb-3">
               <div className="flex items-center gap-4">
-                <div className="w-12 h-12 bg-muted rounded" />
-                <p>{item.name}</p>
+                <img
+                  src={item.book?.images?.[0]?.image?.url}
+                  alt={item.book?.title}
+                  className="w-12 h-12 bg-muted rounded"
+                />
+                <p>{item.book?.title}</p>
               </div>
 
               <div className="flex gap-10 text-sm">
-                <span>{item.qty}</span>
-                <span>${item.price.toFixed(2)}</span>
-                <span>${(item.qty * item.price).toFixed(2)}</span>
+                <span>{item?.quantity}</span>
+                <span>₱{item?.priceSnapshot?.toFixed(2)}</span>
+                <span>
+                  ₱{(item?.quantity * item?.priceSnapshot).toFixed(2)}
+                </span>
               </div>
             </div>
           ))}

--- a/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
@@ -1,7 +1,138 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { CheckCircle, Truck, Package, Clipboard } from "lucide-react";
+
+const steps = [
+  { label: "Processing", icon: CheckCircle, completed: true },
+  { label: "Shipped", icon: Truck, completed: true },
+  { label: "Out for Delivery", icon: Package, completed: false },
+  { label: "Delivered", icon: Clipboard, completed: false },
+];
+
 const OrderDetails = () => {
   return (
-    <div>OrderDetails</div>
-  )
-}
+    <div className="p-6 space-y-6 overflow-auto">
+      {/* Top Section */}
+      <div className="grid md:grid-cols-2 gap-6">
+        {/* Order Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Order ORD-12345</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Placed on 2025-04-15
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="font-semibold">Customer Information</p>
+              <p className="text-sm text-muted-foreground">Alice Johnson</p>
+              <p className="text-sm text-muted-foreground">alice@example.com</p>
+              <p className="text-sm text-muted-foreground">
+                123 Main St, Anytown
+              </p>
+            </div>
 
-export default OrderDetails
+            <Card className="p-4 flex items-center justify-between">
+              <div>
+                <p className="font-medium">Payment Method</p>
+                <p className="text-sm text-muted-foreground">
+                  Visa ending in **** 1234
+                </p>
+              </div>
+            </Card>
+          </CardContent>
+        </Card>
+
+        {/* Summary */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Order Summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex justify-between">
+              <span>Subtotal</span>
+              <span>$101.97</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Shipping</span>
+              <span>$10.00</span>
+            </div>
+            <Separator />
+            <div className="flex justify-between font-semibold">
+              <span>Total</span>
+              <span>$111.97</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Delivery Status */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Delivery Status</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            {steps.map((step, index) => {
+              const Icon = step.icon;
+              return (
+                <div key={index} className="flex flex-col items-center flex-1">
+                  <div
+                    className={`rounded-full p-3 ${
+                      step.completed ? "bg-green-500 text-white" : "bg-muted"
+                    }`}>
+                    <Icon className="w-5 h-5" />
+                  </div>
+                  <p className="text-sm mt-2">{step.label}</p>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Progress bar */}
+          <div className="h-2 bg-muted rounded-full mt-4 overflow-hidden">
+            <div className="h-full bg-black w-1/2" />
+          </div>
+
+          <div className="mt-3">
+            <Badge>Shipped</Badge>
+            <span className="text-sm text-muted-foreground ml-2">
+              on December 23, 2024
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Order Items */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Order Items</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {[
+            { name: "Wireless Headphones", qty: 2, price: 25.99 },
+            { name: "Bluetooth Speaker", qty: 1, price: 49.99 },
+          ].map((item, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between border-b pb-3">
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 bg-muted rounded" />
+                <p>{item.name}</p>
+              </div>
+
+              <div className="flex gap-10 text-sm">
+                <span>{item.qty}</span>
+                <span>${item.price.toFixed(2)}</span>
+                <span>${(item.qty * item.price).toFixed(2)}</span>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+export default OrderDetails;

--- a/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrdersTableColumns.jsx
@@ -6,7 +6,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal } from "lucide-react";
+import { Eye, MoreHorizontal } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const OrdersTableColumns = () => [
   // Order Code
@@ -144,7 +145,11 @@ const OrdersTableColumns = () => [
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="center">
-              <DropdownMenuItem>View</DropdownMenuItem>
+              <DropdownMenuItem>
+                <Link to={`/admin/order/detail/${order.orderCode}`}>
+                  <Eye /> View Order
+                </Link>
+              </DropdownMenuItem>
               <DropdownMenuItem>Update</DropdownMenuItem>
               <DropdownMenuItem className="text-red-500">
                 Cancel


### PR DESCRIPTION
## Summary
Implements the Order Details page for admin with API integration, dynamic data rendering, and delivery status tracking.

## Changes
- Connected Order Details page to `useGetAdminOrderDetail` hook
- Implemented dynamic delivery status stepper
- Added support for `cancelled` status with proper UI handling
- Displayed payment method and conditional transaction ID / order ID fallback
- Added formatters for date and phone number
- Rendered order items with images and computed totals

## Notes
- Assumes backend status enum:
  `pending | paid | shipped | out_for_delivery | delivered | cancelled`
- Transaction ID is shown only when available

## Testing
- Verified order fetch via API
- Tested all status states (including cancelled)
- Checked rendering for missing optional fields (transactionId, phone, etc.)