### PR TITLE
fix(order-details): resolve toFIxed type error caused by null/undefined totalAmount

### DIFF
--- a/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
+++ b/frontend/src/features/admin/orders/pages/components/OrderDetails.jsx
@@ -120,12 +120,12 @@ const OrderDetails = () => {
           <CardContent className="space-y-2">
             <div className="flex justify-between">
               <span>Subtotal</span>
-              <span>₱{order?.totalAmount.toFixed(2)}</span>
+              <span>₱{order?.totalAmount?.toFixed(2)}</span>
             </div>
             <Separator />
             <div className="flex justify-between font-semibold">
               <span>Total</span>
-              <span>₱{order?.totalAmount.toFixed(2)}</span>
+              <span>₱{order?.totalAmount?.toFixed(2)}</span>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
##Summary
 - the bug is caused by viewing older order data that do not have priceSnapshot