### PR TITLE
fix(auth): resolve  refresh infinite loop and multiple refreshToken generation issue

### DIFF
--- a/backend/src/auth/auth_controller.js
+++ b/backend/src/auth/auth_controller.js
@@ -40,9 +40,11 @@ export async function register(req, res) {
 export async function login(req, res) {
   try {
     const { email, password } = req.body;
+    const deviceId = req.headers["x-device-id"];
     const { accessToken, refreshToken } = await authService.loginService({
       email,
       password,
+      deviceId,
     });
 
     // res.cookie("refreshToken", refreshToken, {
@@ -72,8 +74,10 @@ export async function login(req, res) {
 export async function refresh(req, res) {
   try {
     // get refresh token from cookie and send to refresh service
+    const deviceId = req.headers["x-device-id"];
     const { accessToken, refreshToken } = await authService.refreshService(
       req.cookies.refreshToken,
+      deviceId,
     );
     // set new cookie
     // res.cookie("refreshToken", refreshToken, {

--- a/backend/src/auth/auth_services.js
+++ b/backend/src/auth/auth_services.js
@@ -78,26 +78,7 @@ export async function refreshService(refToken) {
     }
     // verify refresh token
     const payload = verifyRefreshToken(refToken);
-    // find token using user id
-    const token = await RefreshToken.findOne({ user: payload.sub });
-    if (!token) {
-      const error = new Error("Token not recognized");
-      error.status = 403;
-      throw error;
-    }
-    if (token.expiresAt < new Date()) {
-      const error = new Error("Token expired");
-      error.status = 401;
-      throw error;
-    }
-    // compare token with hashed token
-    const storedToken = await token.compareRefreshToken(refToken);
 
-    if (!storedToken) {
-      const error = new Error("Token not recognized");
-      error.status = 403;
-      throw error;
-    }
     const tokens = await RefreshToken.find({ user: payload.sub });
     if (!tokens) return;
     let matchedToken = null;
@@ -110,6 +91,16 @@ export async function refreshService(refToken) {
         matchedToken = t;
         break;
       }
+    }
+    if (!matchedToken) {
+      const error = new Error("Token not recognized");
+      error.status = 403;
+      throw error;
+    }
+    if (matchedToken.expiresAt < new Date()) {
+      const error = new Error("Token expired");
+      error.status = 401;
+      throw error;
     }
     // REFRESH ROTATION
     await RefreshToken.deleteOne({ _id: matchedToken._id });

--- a/backend/src/auth/auth_services.js
+++ b/backend/src/auth/auth_services.js
@@ -38,7 +38,7 @@ export async function registerService(user) {
 }
 
 export async function loginService(login) {
-  const { email, password } = login;
+  const { email, password, deviceId } = login;
   const user = await User.findOne({ email: email });
   if (!user) {
     const error = new Error(
@@ -59,62 +59,78 @@ export async function loginService(login) {
   // ISSUE TOKEN
   const accessToken = signAccessToken(user);
   const refreshToken = signRefreshToken(user);
-  // Store refresh token connected to user id
-  await RefreshToken.create({
-    user: user._id,
-    token: refreshToken,
-    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  });
+  // Store refresh token connected to user id and device id
+  await RefreshToken.findOneAndUpdate(
+    { user: user._id, deviceId },
+    {
+      token: refreshToken,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+    { upsert: true, new: true },
+  );
 
   return { accessToken, refreshToken };
 }
 
-export async function refreshService(refToken) {
+export async function refreshService(refToken, deviceId) {
   try {
     if (!refToken) {
       const error = new Error("Token not recognized");
       error.status = 401;
       throw error;
     }
+    if (!deviceId) {
+      const error = new Error("Device ID is required");
+      error.status = 400;
+      throw error;
+    }
     // verify refresh token
     const payload = verifyRefreshToken(refToken);
+    const token = await RefreshToken.findOne({
+      user: payload.sub,
+      deviceId,
+    });
 
-    const tokens = await RefreshToken.find({ user: payload.sub });
-    if (!tokens) return;
-    let matchedToken = null;
-    // loop through to find correct token
-    for (const t of tokens) {
-      // compare each hash
-      const isMatch = await t.compareRefreshToken(refToken);
-      if (isMatch) {
-        // match correct one
-        matchedToken = t;
-        break;
-      }
-    }
-    if (!matchedToken) {
+    if (!token) {
       const error = new Error("Token not recognized");
       error.status = 403;
       throw error;
     }
-    if (matchedToken.expiresAt < new Date()) {
+
+    if (token.expiresAt < new Date()) {
       const error = new Error("Token expired");
       error.status = 401;
       throw error;
     }
-    // REFRESH ROTATION
-    await RefreshToken.deleteOne({ _id: matchedToken._id });
+    const isMatch = await token.compareRefreshToken(refToken);
+
+    if (!isMatch) {
+      // reuse detection
+      await RefreshToken.deleteMany({ user: payload.sub });
+
+      const error = new Error("Token reuse detected");
+      error.status = 403;
+      throw error;
+    }
 
     // check db for user
     const user = await User.findById(payload.sub);
+    if (!user) {
+      const error = new Error("User not found");
+      error.status = 404;
+      throw error;
+    }
     // ISSUE TOKENs
     const accessToken = signAccessToken(user);
     const refreshToken = signRefreshToken(user);
-    await RefreshToken.create({
-      user: user._id,
-      token: refreshToken,
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-    });
+    await RefreshToken.findOneAndUpdate(
+      { user: user._id, deviceId },
+      {
+        token: refreshToken,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+      { new: true },
+    );
 
     return { accessToken, refreshToken };
   } catch (error) {

--- a/backend/src/model/RefreshToken.js
+++ b/backend/src/model/RefreshToken.js
@@ -7,6 +7,7 @@ const refreshTokenSchema = new Schema(
       ref: "User",
       required: true,
     },
+    deviceId: { type: String, required: true },
     token: {
       type: String,
       required: true,

--- a/frontend/src/features/auth/api/auth.js
+++ b/frontend/src/features/auth/api/auth.js
@@ -4,12 +4,16 @@ import api from "../../../services/axios.js";
 // It contains NO UI logic.
 
 export const loginRequest = async (data) => {
-  const response = await api.post("/auth/login", data);
+  const response = await api.post("/auth/login", data, {
+    skipAuthRefresh: true,
+  });
   return response.data;
 };
 
 export const signupRequest = async (data) => {
-  const response = await api.post("/auth/register", data);
+  const response = await api.post("/auth/register", data, {
+    skipAuthRefresh: true,
+  });
   return response.data;
 };
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,6 +1,17 @@
 import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge"
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
+}
+export function getOrCreateDeviceId() {
+  let deviceId = localStorage.getItem("deviceId");
+
+  if (!deviceId) {
+    // Use the built-in Web Crypto API to generate deviceId
+    deviceId = crypto.randomUUID();
+    localStorage.setItem("deviceId", deviceId);
+  }
+
+  return deviceId;
 }

--- a/frontend/src/services/axios.js
+++ b/frontend/src/services/axios.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useAuthStore } from "@/features/auth/store/authStore.js";
+import { getOrCreateDeviceId } from "@/lib/utils";
 // This is your centralized HTTP client.
 // ALL API calls go through this instance.
 
@@ -19,7 +20,8 @@ api.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
-
+  // send device id to backend
+  config.headers["x-device-id"] = getOrCreateDeviceId();
   return config;
 });
 api.interceptors.response.use(

--- a/frontend/src/services/axios.js
+++ b/frontend/src/services/axios.js
@@ -27,7 +27,9 @@ api.interceptors.response.use(
 
   async (error) => {
     const originalRequest = error.config;
-
+    if (originalRequest?.skipAuthRefresh) {
+      return Promise.reject(error);
+    }
     // If 401 AND request hasn't already retried
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true; // prevent infinite loop

--- a/frontend/src/services/axios.js
+++ b/frontend/src/services/axios.js
@@ -30,13 +30,20 @@ api.interceptors.response.use(
     if (originalRequest?.skipAuthRefresh) {
       return Promise.reject(error);
     }
+    // explicit guard for refresh endpoint
+    const isRefreshRequest = originalRequest.url?.includes("/auth/refresh");
+    if (isRefreshRequest) {
+      return Promise.reject(error);
+    }
     // If 401 AND request hasn't already retried
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true; // prevent infinite loop
 
       try {
         // Call refresh endpoint
-        const res = await api.post("/auth/refresh");
+        const res = await api.post("/auth/refresh", null, {
+          skipAuthRefresh: true,
+        });
 
         const newAccessToken = res.data.accessToken;
         // Save new token in Zustand


### PR DESCRIPTION
This PR improves authentication flow by fixing refresh token issues, preventing infinite loops, and introducing device-based session management.
## Changes
### Fixes
- Fix infinite refresh loop caused by interceptor retrying /auth/refresh
- Ensure interceptors skip auth endpoints (login, signup, refresh)
- Prevent repeated "Token expired" errors
- Remove redundant findOne query in refresh service

### Features
- Add deviceId support for per-device session tracking
- Generate deviceId on client using crypto.randomUUID()
- Attach deviceId via request headers (x-device-id)
- Store and manage refresh tokens per device

### Refactors
- Simplify refresh token lookup (direct query instead of iteration)
- Clean up interceptor logic and retry handling
