### PR TITLE
fix(auth): require device ID for logout token invalidation

### DIFF
--- a/backend/src/auth/auth_controller.js
+++ b/backend/src/auth/auth_controller.js
@@ -104,7 +104,8 @@ export async function refresh(req, res) {
 
 export async function logout(req, res) {
   try {
-    await authService.logoutService(req.cookies.refreshToken);
+    const deviceId = req.headers["x-device-id"];
+    await authService.logoutService(req.cookies.refreshToken, deviceId);
     return res.status(200).json({
       message: "Logged out successfully",
     });

--- a/backend/src/auth/auth_services.js
+++ b/backend/src/auth/auth_services.js
@@ -139,28 +139,21 @@ export async function refreshService(refToken, deviceId) {
   }
 }
 
-export async function logoutService(refreshToken) {
+export async function logoutService(refreshToken, deviceId) {
   try {
     if (!refreshToken) return;
+    if (!deviceId) {
+      const error = new Error("Device ID is required");
+      error.status = 400;
+      throw error;
+    }
     // verify refresh token
     const payload = verifyRefreshToken(refreshToken);
-    // find all tokens that belong to user
-    const tokens = await RefreshToken.find({ user: payload.sub });
-    if (!tokens) return;
-    let matchedToken = null;
-    // loop through to find correct token
-    for (const t of tokens) {
-      // compare each hash
-      const isMatch = await t.compareRefreshToken(refreshToken);
-      if (isMatch) {
-        // match correct one
-        matchedToken = t;
-        break;
-      }
-    }
-
-    if (!matchedToken) throw error;
-    return await RefreshToken.deleteOne({ _id: matchedToken._id });
+    const token = await RefreshToken.findOne({
+      user: payload.sub,
+      deviceId,
+    });
+    return await RefreshToken.deleteOne({ _id: token._id });
   } catch (error) {
     console.log("Error logout service", error.message || error);
     throw error;


### PR DESCRIPTION
## Summary
This change updates the logout flow so refresh token invalidation is tied to the current device instead of scanning all stored tokens for a user.

### Changes
The logout controller now reads the x-device-id header and passes it to the auth service. The logout service requires that device ID, returns a 400 error when it is missing, and deletes the refresh token record associated with the authenticated user and that device.