### PR TITLE
feat(dashboard): add admin dashboard data visualization

### DIFF
--- a/backend/src/controllers/admin/analytics/admin_dashboard_controller.js
+++ b/backend/src/controllers/admin/analytics/admin_dashboard_controller.js
@@ -1,0 +1,12 @@
+import * as adminDashboardService from "../../../services/analytics/admin_dashboard_services.js";
+
+export async function getDashboardRevenue(req, res) {
+  try {
+    const revenue = await adminDashboardService.getDashboardRevenueService();
+    res.status(200).json({ revenue });
+  } catch (error) {
+    res
+      .status(500)
+      .json({ message: error.message || "Failed to fetch dashboard revenue" });
+  }
+}

--- a/backend/src/routes/admin_routes.js
+++ b/backend/src/routes/admin_routes.js
@@ -8,6 +8,7 @@ import * as adminHomePageSection from "../controllers/admin/content/admin_homepa
 import * as adminMedia from "../controllers/admin/content/admin_media_controller.js";
 import * as adminBanners from "../controllers/admin/content/admin_banners_controller.js";
 import * as adminFeaturedItems from "../controllers/admin/content/admin_featureditems_controller.js";
+import * as adminDashboard from "../controllers/admin/analytics/admin_dashboard_controller.js";
 
 import { adminOnly } from "../middleware/roles.js";
 import { uploadImage, requireFiles } from "../middleware/upload.js";
@@ -98,5 +99,8 @@ router.delete(
   adminOnly,
   adminFeaturedItems.removeFeaturedItem,
 );
+
+// DASHBOARD
+router.get("/dashboard/revenue", adminOnly, adminDashboard.getDashboardRevenue);
 
 export default router;

--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -1,9 +1,22 @@
 import { Order } from "../../model/index.js";
+import { ORDER_STATUSES } from "../../constants/constant_values.js";
+
+const NON_REVENUE_ORDER_STATUSES = [
+  ORDER_STATUSES.CANCELLED,
+  ORDER_STATUSES.FAILED,
+  ORDER_STATUSES.PENDING,
+];
 
 export async function getDashboardRevenueService() {
   try {
     const revenueSummary = await getRevenueSummaryService();
+    const summary = await Order.find({
+      status: { $nin: NON_REVENUE_ORDER_STATUSES },
+    })
+      .select("totalAmount updatedAt")
+      .lean();
     return {
+      summary,
       totalRevenue: revenueSummary.totalRevenue,
       thisYearRevenue: revenueSummary.thisYearRevenue,
       lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,
@@ -46,7 +59,7 @@ const getRevenueSummaryService = async () => {
       {
         $match: {
           status: {
-            $nin: ["cancelled", "payment failed", "pending"],
+            $nin: NON_REVENUE_ORDER_STATUSES,
           },
         },
       },

--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -1,0 +1,127 @@
+import { Order } from "../../model/index.js";
+
+export async function getDashboardRevenueService() {
+  try {
+    const revenueSummary = await getRevenueSummaryService();
+    return {
+      totalRevenue: revenueSummary.totalRevenue,
+      thisYearRevenue: revenueSummary.thisYearRevenue,
+      lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,
+      todayRevenue: revenueSummary.todayRevenue,
+    };
+  } catch (error) {
+    throw new Error(error.message || "Failed to fetch dashboard revenue");
+  }
+}
+
+const getRevenueSummaryService = async () => {
+  try {
+    // Build the current date once to keep all time filters consistent.
+    const now = new Date();
+
+    // Start of the current year (Jan 1, 00:00:00.000).
+    const startOfYear = new Date(now.getFullYear(), 0, 1);
+
+    // Start of today in local server time.
+    const startOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+
+    // End of today in local server time.
+    const endOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() + 1,
+    );
+
+    // Start date for "last 6 months" window.
+    const sixMonthsAgo = new Date(now);
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+    // One query, multiple buckets: total, this year, last 6 months, and today.
+    const [summary] = await Order.aggregate([
+      // Ignore non-revenue order statuses before doing any calculations.
+      {
+        $match: {
+          status: {
+            $nin: ["cancelled", "payment failed", "pending"],
+          },
+        },
+      },
+      // Compute multiple totals in parallel from the same filtered dataset.
+      {
+        $facet: {
+          total: [
+            // Sum all valid order amounts.
+            {
+              $group: {
+                _id: null,
+                amount: { $sum: "$totalAmount" },
+              },
+            },
+          ],
+          thisYear: [
+            // Keep only orders created from the start of this year.
+            {
+              $match: {
+                createdAt: { $gte: startOfYear },
+              },
+            },
+            // Sum this year's order amounts.
+            {
+              $group: {
+                _id: null,
+                amount: { $sum: "$totalAmount" },
+              },
+            },
+          ],
+          lastSixMonths: [
+            // Keep only orders created in the last 6 months.
+            {
+              $match: {
+                createdAt: { $gte: sixMonthsAgo },
+              },
+            },
+            // Sum order amounts for the 6-month window.
+            {
+              $group: {
+                _id: null,
+                amount: { $sum: "$totalAmount" },
+              },
+            },
+          ],
+          today: [
+            // Keep only orders created today.
+            {
+              $match: {
+                createdAt: {
+                  $gte: startOfToday,
+                  $lt: endOfToday,
+                },
+              },
+            },
+            // Sum today's order amounts.
+            {
+              $group: {
+                _id: null,
+                amount: { $sum: "$totalAmount" },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    // Return numeric totals with safe fallbacks when no documents match.
+    return {
+      totalRevenue: summary?.total?.[0]?.amount || 0,
+      thisYearRevenue: summary?.thisYear?.[0]?.amount || 0,
+      lastSixMonthsRevenue: summary?.lastSixMonths?.[0]?.amount || 0,
+      todayRevenue: summary?.today?.[0]?.amount || 0,
+    };
+  } catch (error) {
+    throw new Error(error.message || "Failed to fetch revenue summary");
+  }
+};

--- a/frontend/src/features/admin/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboard.jsx
@@ -2,7 +2,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DashboardCards from "./components/DashboardCards";
 import DashboardCharts from "./components/DashboardCharts";
 import { useGetDashboardRevenue } from "./hooks/admin_dashboard_hooks";
-import { dashboardRevenue } from "./util/dashboardStats";
+import { dashboardRevenue, revenueChartData } from "./util/dashboardStats";
 const AdminDashboard = () => {
   const { data: revenue } = useGetDashboardRevenue();
   return (
@@ -18,7 +18,10 @@ const AdminDashboard = () => {
             <div className="flex flex-col gap-4 md:gap-6">
               <DashboardCards data={dashboardRevenue(revenue)} />
               <div className="px-4 lg:px-6">
-                <DashboardCharts />
+                <DashboardCharts
+                  chartData={revenueChartData(revenue?.revenue?.summary)}
+                  title="Revenue Summary"
+                />
               </div>
               {/* <DataTable data={data} /> */}
             </div>

--- a/frontend/src/features/admin/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboard.jsx
@@ -1,20 +1,36 @@
-import DashboardSidebar from "./components/DashboardSidebar";
-import DashboardCharts from "./components/DashboardCharts";
-import DashboardHeader from "./components/DashboardHeader";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DashboardCards from "./components/DashboardCards";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import DashboardCharts from "./components/DashboardCharts";
+import { useGetDashboardRevenue } from "./hooks/admin_dashboard_hooks";
+import { dashboardRevenue } from "./util/dashboardStats";
 const AdminDashboard = () => {
+  const { data: revenue } = useGetDashboardRevenue();
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-      <div className="@container/main flex flex-1 flex-col gap-2">
-        <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-          <DashboardCards />
-          <div className="px-4 lg:px-6">
-            <DashboardCharts />
+      <Tabs defaultValue="revenue" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-3 sticky top-0 z-10">
+          <TabsTrigger value="revenue">Revenue</TabsTrigger>
+          <TabsTrigger value="visits">Visits</TabsTrigger>
+          <TabsTrigger value="analytics">Analytics</TabsTrigger>
+        </TabsList>
+        <TabsContent value="revenue" className="space-y-6 overflow-auto">
+          <div className="@container/main flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-4 md:gap-6">
+              <DashboardCards data={dashboardRevenue(revenue)} />
+              <div className="px-4 lg:px-6">
+                <DashboardCharts />
+              </div>
+              {/* <DataTable data={data} /> */}
+            </div>
           </div>
-          {/* <DataTable data={data} /> */}
-        </div>
-      </div>
+        </TabsContent>
+        <TabsContent value="visits" className="space-y-6">
+          {/* Visits content */}
+        </TabsContent>
+        <TabsContent value="analytics" className="space-y-6">
+          {/* Analytics content */}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 };

--- a/frontend/src/features/admin/dashboard/api/admin_dashboard_api.js
+++ b/frontend/src/features/admin/dashboard/api/admin_dashboard_api.js
@@ -1,0 +1,6 @@
+import api from "@/services/axios";
+
+export const getDashboardRevenueRequest = async () => {
+  const response = await api.get("/admin/dashboard/revenue");
+  return response.data;
+};

--- a/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
@@ -8,100 +8,100 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { TrendingDown, TrendingUp } from "lucide-react";
-const DashboardCards = () => {
+const DashboardCards = ({ data }) => {
   return (
     <div className="grid grid-cols-1 gap-4 px-4 lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
       <Card className="rounded-lg shadow-md p-6 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)]">
         <CardHeader>
-          <CardDescription>Total Revenue</CardDescription>
+          <CardDescription>{data?.card1.label}</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            $1,250.00
+            {data.card1.value.toLocaleString()}
           </CardTitle>
-          <CardAction>
+          {/* <CardAction>
             <Badge
               variant="secondary"
               className="bg-[var(--color-positive-light)] text-[var(--color-positive)]">
               <TrendingUp />
               +12.5%
             </Badge>
-          </CardAction>
+          </CardAction> */}
         </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
+        {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
             Trending up this month <TrendingUp className="size-4" />
           </div>
           <div className="text-muted-foreground">
             Visitors for the last 6 months
           </div>
-        </CardFooter>
+        </CardFooter> */}
       </Card>
       <Card className="rounded-lg shadow-md p-6 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)]">
         <CardHeader>
-          <CardDescription>New Customers</CardDescription>
+          <CardDescription>{data?.card2.label}</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            1,234
+            {data.card2.value.toLocaleString()}
           </CardTitle>
-          <CardAction>
+          {/* <CardAction>
             <Badge
               variant="secondary"
               className="bg-[var(--color-negative-light)] text-[var(--color-negative)]">
               <TrendingDown />
               -20%
             </Badge>
-          </CardAction>
+          </CardAction> */}
         </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Down 20% this period <TrendingDown className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Acquisition needs attention
-          </div>
-        </CardFooter>
+        {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
+            <div className="line-clamp-1 flex gap-2 font-medium">
+              Down 20% this period <TrendingDown className="size-4" />
+            </div>
+            <div className="text-muted-foreground">
+              Acquisition needs attention
+            </div>
+          </CardFooter> */}
       </Card>
       <Card className="rounded-lg shadow-md p-6 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)]">
         <CardHeader>
-          <CardDescription>Active Accounts</CardDescription>
+          <CardDescription>{data?.card3.label}</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            45,678
+            {data.card3.value.toLocaleString()}
           </CardTitle>
-          <CardAction>
+          {/* <CardAction>
             <Badge
               variant="secondary"
               className="bg-[var(--color-positive-light)] text-[var(--color-positive)]">
               <TrendingUp />
               +12.5%
             </Badge>
-          </CardAction>
+          </CardAction> */}
         </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
+        {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
             Strong user retention <TrendingUp className="size-4" />
           </div>
           <div className="text-muted-foreground">Engagement exceed targets</div>
-        </CardFooter>
+        </CardFooter> */}
       </Card>
       <Card className="rounded-lg shadow-md p-6 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)]">
         <CardHeader>
-          <CardDescription>Growth Rate</CardDescription>
+          <CardDescription>{data?.card4.label}</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            4.5%
+            {data.card4.value.toLocaleString()}
           </CardTitle>
-          <CardAction>
+          {/* <CardAction>
             <Badge
               variant="secondary"
               className="bg-[var(--color-positive-light)] text-[var(--color-positive)]">
               <TrendingUp />
               +4.5%
             </Badge>
-          </CardAction>
+          </CardAction> */}
         </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
+        {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
             Steady performance increase <TrendingUp className="size-4" />
           </div>
           <div className="text-muted-foreground">Meets growth projections</div>
-        </CardFooter>
+        </CardFooter> */}
       </Card>
     </div>
   );

--- a/frontend/src/features/admin/dashboard/components/DashboardCharts.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCharts.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 
 import { useIsMobile } from "@/components/hooks/use-mobile";
@@ -24,157 +24,93 @@ import {
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
-export const description = "An interactive area chart";
-
-const chartData = [
-  { date: "2024-04-01", desktop: 222, mobile: 150 },
-  { date: "2024-04-02", desktop: 97, mobile: 180 },
-  { date: "2024-04-03", desktop: 167, mobile: 120 },
-  { date: "2024-04-04", desktop: 242, mobile: 260 },
-  { date: "2024-04-05", desktop: 373, mobile: 290 },
-  { date: "2024-04-06", desktop: 301, mobile: 340 },
-  { date: "2024-04-07", desktop: 245, mobile: 180 },
-  { date: "2024-04-08", desktop: 409, mobile: 320 },
-  { date: "2024-04-09", desktop: 59, mobile: 110 },
-  { date: "2024-04-10", desktop: 261, mobile: 190 },
-  { date: "2024-04-11", desktop: 327, mobile: 350 },
-  { date: "2024-04-12", desktop: 292, mobile: 210 },
-  { date: "2024-04-13", desktop: 342, mobile: 380 },
-  { date: "2024-04-14", desktop: 137, mobile: 220 },
-  { date: "2024-04-15", desktop: 120, mobile: 170 },
-  { date: "2024-04-16", desktop: 138, mobile: 190 },
-  { date: "2024-04-17", desktop: 446, mobile: 360 },
-  { date: "2024-04-18", desktop: 364, mobile: 410 },
-  { date: "2024-04-19", desktop: 243, mobile: 180 },
-  { date: "2024-04-20", desktop: 89, mobile: 150 },
-  { date: "2024-04-21", desktop: 137, mobile: 200 },
-  { date: "2024-04-22", desktop: 224, mobile: 170 },
-  { date: "2024-04-23", desktop: 138, mobile: 230 },
-  { date: "2024-04-24", desktop: 387, mobile: 290 },
-  { date: "2024-04-25", desktop: 215, mobile: 250 },
-  { date: "2024-04-26", desktop: 75, mobile: 130 },
-  { date: "2024-04-27", desktop: 383, mobile: 420 },
-  { date: "2024-04-28", desktop: 122, mobile: 180 },
-  { date: "2024-04-29", desktop: 315, mobile: 240 },
-  { date: "2024-04-30", desktop: 454, mobile: 380 },
-  { date: "2024-05-01", desktop: 165, mobile: 220 },
-  { date: "2024-05-02", desktop: 293, mobile: 310 },
-  { date: "2024-05-03", desktop: 247, mobile: 190 },
-  { date: "2024-05-04", desktop: 385, mobile: 420 },
-  { date: "2024-05-05", desktop: 481, mobile: 390 },
-  { date: "2024-05-06", desktop: 498, mobile: 520 },
-  { date: "2024-05-07", desktop: 388, mobile: 300 },
-  { date: "2024-05-08", desktop: 149, mobile: 210 },
-  { date: "2024-05-09", desktop: 227, mobile: 180 },
-  { date: "2024-05-10", desktop: 293, mobile: 330 },
-  { date: "2024-05-11", desktop: 335, mobile: 270 },
-  { date: "2024-05-12", desktop: 197, mobile: 240 },
-  { date: "2024-05-13", desktop: 197, mobile: 160 },
-  { date: "2024-05-14", desktop: 448, mobile: 490 },
-  { date: "2024-05-15", desktop: 473, mobile: 380 },
-  { date: "2024-05-16", desktop: 338, mobile: 400 },
-  { date: "2024-05-17", desktop: 499, mobile: 420 },
-  { date: "2024-05-18", desktop: 315, mobile: 350 },
-  { date: "2024-05-19", desktop: 235, mobile: 180 },
-  { date: "2024-05-20", desktop: 177, mobile: 230 },
-  { date: "2024-05-21", desktop: 82, mobile: 140 },
-  { date: "2024-05-22", desktop: 81, mobile: 120 },
-  { date: "2024-05-23", desktop: 252, mobile: 290 },
-  { date: "2024-05-24", desktop: 294, mobile: 220 },
-  { date: "2024-05-25", desktop: 201, mobile: 250 },
-  { date: "2024-05-26", desktop: 213, mobile: 170 },
-  { date: "2024-05-27", desktop: 420, mobile: 460 },
-  { date: "2024-05-28", desktop: 233, mobile: 190 },
-  { date: "2024-05-29", desktop: 78, mobile: 130 },
-  { date: "2024-05-30", desktop: 340, mobile: 280 },
-  { date: "2024-05-31", desktop: 178, mobile: 230 },
-  { date: "2024-06-01", desktop: 178, mobile: 200 },
-  { date: "2024-06-02", desktop: 470, mobile: 410 },
-  { date: "2024-06-03", desktop: 103, mobile: 160 },
-  { date: "2024-06-04", desktop: 439, mobile: 380 },
-  { date: "2024-06-05", desktop: 88, mobile: 140 },
-  { date: "2024-06-06", desktop: 294, mobile: 250 },
-  { date: "2024-06-07", desktop: 323, mobile: 370 },
-  { date: "2024-06-08", desktop: 385, mobile: 320 },
-  { date: "2024-06-09", desktop: 438, mobile: 480 },
-  { date: "2024-06-10", desktop: 155, mobile: 200 },
-  { date: "2024-06-11", desktop: 92, mobile: 150 },
-  { date: "2024-06-12", desktop: 492, mobile: 420 },
-  { date: "2024-06-13", desktop: 81, mobile: 130 },
-  { date: "2024-06-14", desktop: 426, mobile: 380 },
-  { date: "2024-06-15", desktop: 307, mobile: 350 },
-  { date: "2024-06-16", desktop: 371, mobile: 310 },
-  { date: "2024-06-17", desktop: 475, mobile: 520 },
-  { date: "2024-06-18", desktop: 107, mobile: 170 },
-  { date: "2024-06-19", desktop: 341, mobile: 290 },
-  { date: "2024-06-20", desktop: 408, mobile: 450 },
-  { date: "2024-06-21", desktop: 169, mobile: 210 },
-  { date: "2024-06-22", desktop: 317, mobile: 270 },
-  { date: "2024-06-23", desktop: 480, mobile: 530 },
-  { date: "2024-06-24", desktop: 132, mobile: 180 },
-  { date: "2024-06-25", desktop: 141, mobile: 190 },
-  { date: "2024-06-26", desktop: 434, mobile: 380 },
-  { date: "2024-06-27", desktop: 448, mobile: 490 },
-  { date: "2024-06-28", desktop: 149, mobile: 200 },
-  { date: "2024-06-29", desktop: 103, mobile: 160 },
-  { date: "2024-06-30", desktop: 446, mobile: 400 },
-];
-
 const chartConfig = {
-  desktop: {
-    label: "Desktop",
+  totalRevenue: {
+    label: "Revenue",
     color: "var(--chart-1)",
   },
-  mobile: {
-    label: "Mobile",
-    color: "var(--chart-2)",
-  },
 };
-const DashboardCharts = () => {
-  const isMobile = useIsMobile();
-  const [timeRange, setTimeRange] = useState("90d");
 
-  useEffect(() => {
-    if (isMobile) {
-      setTimeRange("7d");
-    }
-  }, [isMobile]);
+const TIME_RANGE_DAYS = {
+  "7d": 7,
+  "30d": 30,
+  "180d": 180,
+  "365d": 365,
+};
 
-  const filteredData = chartData.filter((item) => {
-    const date = new Date(item.date);
-    const referenceDate = new Date("2024-06-30");
-    let daysToSubtract = 90;
-    if (timeRange === "30d") {
-      daysToSubtract = 30;
-    } else if (timeRange === "7d") {
-      daysToSubtract = 7;
-    }
-    const startDate = new Date(referenceDate);
-    startDate.setDate(startDate.getDate() - daysToSubtract);
-    return date >= startDate;
+const toLocalDateKey = (value) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const buildDateSeries = (rawData, days) => {
+  const endDate = new Date();
+  endDate.setHours(23, 59, 59, 999);
+
+  const startDate = new Date(endDate);
+  startDate.setDate(startDate.getDate() - (days - 1));
+  startDate.setHours(0, 0, 0, 0);
+
+  const totalsByDay = new Map();
+  rawData?.forEach((item) => {
+    const key = toLocalDateKey(item?.date);
+    if (!key) return;
+
+    const amount = Number(item?.totalRevenue ?? item?.totalAmount ?? 0);
+    totalsByDay.set(key, (totalsByDay.get(key) || 0) + amount);
   });
+
+  const series = [];
+  const cursor = new Date(startDate);
+  while (cursor <= endDate) {
+    const key = toLocalDateKey(cursor);
+    series.push({
+      date: key,
+      totalRevenue: totalsByDay.get(key) || 0,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return series;
+};
+
+const DashboardCharts = ({ chartData, title }) => {
+  const isMobile = useIsMobile();
+  const [timeRange, setTimeRange] = useState("7d");
+  const activeTimeRange = isMobile ? "7d" : timeRange;
+
+  const handleTimeRangeChange = (nextRange) => {
+    if (!nextRange) return;
+    setTimeRange(nextRange);
+  };
+
+  const filteredData = useMemo(() => {
+    const days = TIME_RANGE_DAYS[activeTimeRange] ?? 7;
+    return buildDateSeries(chartData, days);
+  }, [chartData, activeTimeRange]);
   return (
     <Card className="@container/card">
       <CardHeader>
-        <CardTitle>Total Visitors</CardTitle>
-        <CardDescription>
-          <span className="hidden @[540px]/card:block">
-            Total for the last 3 months
-          </span>
-          <span className="@[540px]/card:hidden">Last 3 months</span>
-        </CardDescription>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription></CardDescription>
         <CardAction>
           <ToggleGroup
             type="single"
-            value={timeRange}
-            onValueChange={setTimeRange}
+            value={activeTimeRange}
+            onValueChange={handleTimeRangeChange}
             variant="outline"
             className="hidden *:data-[slot=toggle-group-item]:px-4! @[767px]/card:flex">
-            <ToggleGroupItem value="90d">Last 3 months</ToggleGroupItem>
-            <ToggleGroupItem value="30d">Last 30 days</ToggleGroupItem>
             <ToggleGroupItem value="7d">Last 7 days</ToggleGroupItem>
+            <ToggleGroupItem value="30d">Last 30 days</ToggleGroupItem>
+            <ToggleGroupItem value="180d">Last 6 months</ToggleGroupItem>
+            <ToggleGroupItem value="365d">Last 12 months</ToggleGroupItem>
           </ToggleGroup>
-          <Select value={timeRange} onValueChange={setTimeRange}>
+          <Select value={activeTimeRange} onValueChange={handleTimeRangeChange}>
             <SelectTrigger
               className="flex w-40 **:data-[slot=select-value]:block **:data-[slot=select-value]:truncate @[767px]/card:hidden"
               size="sm"
@@ -182,14 +118,17 @@ const DashboardCharts = () => {
               <SelectValue placeholder="Last 3 months" />
             </SelectTrigger>
             <SelectContent className="rounded-xl">
-              <SelectItem value="90d" className="rounded-lg">
-                Last 3 months
+              <SelectItem value="7d" className="rounded-lg">
+                Last 7 days
               </SelectItem>
               <SelectItem value="30d" className="rounded-lg">
                 Last 30 days
               </SelectItem>
-              <SelectItem value="7d" className="rounded-lg">
-                Last 7 days
+              <SelectItem value="180d" className="rounded-lg">
+                Last 6 months
+              </SelectItem>
+              <SelectItem value="365d" className="rounded-lg">
+                Last 12 months
               </SelectItem>
             </SelectContent>
           </Select>
@@ -201,7 +140,7 @@ const DashboardCharts = () => {
           className="aspect-auto h-[250px] w-full">
           <AreaChart data={filteredData}>
             <defs>
-              <linearGradient id="fillDesktop" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="revenue" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
                   stopColor="var(--chart-1)"
@@ -214,7 +153,7 @@ const DashboardCharts = () => {
                 />
               </linearGradient>
 
-              <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
+              {/* <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
                   stopColor="var(--chart-2)"
@@ -225,7 +164,7 @@ const DashboardCharts = () => {
                   stopColor="var(--chart-2)"
                   stopOpacity={0.05}
                 />
-              </linearGradient>
+              </linearGradient> */}
             </defs>
             <CartesianGrid
               vertical={false}
@@ -261,18 +200,18 @@ const DashboardCharts = () => {
               }
             />
             <Area
-              dataKey="desktop"
+              dataKey="totalRevenue"
               stroke="var(--chart-1)"
-              fill="url(#fillDesktop)"
+              fill="url(#revenue)"
               strokeWidth={2}
             />
-
+            {/* 
             <Area
               dataKey="mobile"
               stroke="var(--chart-2)"
               fill="url(#fillMobile)"
               strokeWidth={2}
-            />
+            /> */}
           </AreaChart>
         </ChartContainer>
       </CardContent>

--- a/frontend/src/features/admin/dashboard/hooks/admin_dashboard_hooks.js
+++ b/frontend/src/features/admin/dashboard/hooks/admin_dashboard_hooks.js
@@ -1,0 +1,10 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getDashboardRevenueRequest } from "../api/admin_dashboard_api";
+
+export const useGetDashboardRevenue = () => {
+  return useQuery({
+    queryKey: ["dashboardRevenue"],
+    queryFn: () => getDashboardRevenueRequest(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+};

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -1,0 +1,15 @@
+export const dashboardRevenue = (revenue) => ({
+  card1: {
+    label: "Total Revenue",
+    value: `₱${revenue?.revenue?.totalRevenue || 0}`,
+  },
+  card2: {
+    label: "This Year",
+    value: `₱${revenue?.revenue?.thisYearRevenue || 0}`,
+  },
+  card3: {
+    label: "Last 6 Months",
+    value: `₱${revenue?.revenue?.lastSixMonthsRevenue || 0}`,
+  },
+  card4: { label: "Today", value: `₱${revenue?.revenue?.todayRevenue || 0}` },
+});

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -13,3 +13,10 @@ export const dashboardRevenue = (revenue) => ({
   },
   card4: { label: "Today", value: `₱${revenue?.revenue?.todayRevenue || 0}` },
 });
+
+export const revenueChartData = (data) => {
+  return data?.map((item) => ({
+    date: item?.updatedAt,
+    totalRevenue: item?.totalAmount || 0,
+  }));
+};


### PR DESCRIPTION
## Summary
This pr updates admin dashboard to use existing DashboardCards and DashboardCharts as reusable components

### Changes
- added revenue, visits, analytics  tabs for switching data visualization
- added get revenue hook and api request for data visualization
- implemented revenue data to be visualized in cards and charts 
- added  dashboardStats utility function to normalize data fetched 

 ### Testing
- login as admin cycle through the tabs, although only revenue works/displays data
