### PR TITLE
fix(dashboard): refactor dashboard chart data

### DIFF
--- a/frontend/src/features/admin/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboard.jsx
@@ -3,6 +3,7 @@ import DashboardCards from "./components/DashboardCards";
 import DashboardCharts from "./components/DashboardCharts";
 import { useGetDashboardRevenue } from "./hooks/admin_dashboard_hooks";
 import { dashboardRevenue, revenueChartData } from "./util/dashboardStats";
+import { revenueChartConfig } from "./util/chartConfig";
 const AdminDashboard = () => {
   const { data: revenue } = useGetDashboardRevenue();
   return (
@@ -21,6 +22,7 @@ const AdminDashboard = () => {
                 <DashboardCharts
                   chartData={revenueChartData(revenue?.revenue?.summary)}
                   title="Revenue Summary"
+                  chartConfig={revenueChartConfig}
                 />
               </div>
               {/* <DataTable data={data} /> */}

--- a/frontend/src/features/admin/dashboard/components/DashboardCharts.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCharts.jsx
@@ -24,12 +24,7 @@ import {
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
-const chartConfig = {
-  totalRevenue: {
-    label: "Revenue",
-    color: "var(--chart-1)",
-  },
-};
+
 
 const TIME_RANGE_DAYS = {
   "7d": 7,
@@ -61,7 +56,7 @@ const buildDateSeries = (rawData, days) => {
     const key = toLocalDateKey(item?.date);
     if (!key) return;
 
-    const amount = Number(item?.totalRevenue ?? item?.totalAmount ?? 0);
+    const amount = Number(item?.data1 ?? item?.totalAmount ?? 0);
     totalsByDay.set(key, (totalsByDay.get(key) || 0) + amount);
   });
 
@@ -71,7 +66,7 @@ const buildDateSeries = (rawData, days) => {
     const key = toLocalDateKey(cursor);
     series.push({
       date: key,
-      totalRevenue: totalsByDay.get(key) || 0,
+      data1: totalsByDay.get(key) || 0,
     });
     cursor.setDate(cursor.getDate() + 1);
   }
@@ -79,7 +74,7 @@ const buildDateSeries = (rawData, days) => {
   return series;
 };
 
-const DashboardCharts = ({ chartData, title }) => {
+const DashboardCharts = ({ chartData, title, chartConfig }) => {
   const isMobile = useIsMobile();
   const [timeRange, setTimeRange] = useState("7d");
   const activeTimeRange = isMobile ? "7d" : timeRange;
@@ -140,7 +135,7 @@ const DashboardCharts = ({ chartData, title }) => {
           className="aspect-auto h-[250px] w-full">
           <AreaChart data={filteredData}>
             <defs>
-              <linearGradient id="revenue" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="data1" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
                   stopColor="var(--chart-1)"
@@ -153,7 +148,7 @@ const DashboardCharts = ({ chartData, title }) => {
                 />
               </linearGradient>
 
-              {/* <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="data2" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
                   stopColor="var(--chart-2)"
@@ -164,7 +159,7 @@ const DashboardCharts = ({ chartData, title }) => {
                   stopColor="var(--chart-2)"
                   stopOpacity={0.05}
                 />
-              </linearGradient> */}
+              </linearGradient>
             </defs>
             <CartesianGrid
               vertical={false}
@@ -200,18 +195,18 @@ const DashboardCharts = ({ chartData, title }) => {
               }
             />
             <Area
-              dataKey="totalRevenue"
+              dataKey="data1"
               stroke="var(--chart-1)"
-              fill="url(#revenue)"
+              fill="url(#data1)"
               strokeWidth={2}
             />
-            {/* 
+            
             <Area
-              dataKey="mobile"
+              dataKey="data2"
               stroke="var(--chart-2)"
-              fill="url(#fillMobile)"
+              fill="url(#data2)"
               strokeWidth={2}
-            /> */}
+            />
           </AreaChart>
         </ChartContainer>
       </CardContent>

--- a/frontend/src/features/admin/dashboard/util/chartConfig.js
+++ b/frontend/src/features/admin/dashboard/util/chartConfig.js
@@ -1,0 +1,6 @@
+export const revenueChartConfig = {
+  data1: {
+    label: "Revenue",
+    color: "var(--chart-1)",
+  },
+};

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -17,6 +17,6 @@ export const dashboardRevenue = (revenue) => ({
 export const revenueChartData = (data) => {
   return data?.map((item) => ({
     date: item?.updatedAt,
-    totalRevenue: item?.totalAmount || 0,
+    data1: item?.totalAmount || 0,
   }));
 };


### PR DESCRIPTION
## Summary
this pr updates revenueChartData in dashboardStats and DashboardCharts to use data1 instead of totalRevenue

### Changes
- added chartConfig.js to contain configs of other sections/data visualization
- imported revenueChartConfig to AdminDashboard and passed to DashboardChart