### PR TITLE
fix(dashboard-revenue): refactor get revenue data to use paitAt instead of updatedAt

### DIFF
--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -1,5 +1,8 @@
 import { Order } from "../../model/index.js";
-import { ORDER_STATUSES } from "../../constants/constant_values.js";
+import {
+  ORDER_STATUSES,
+  PAYMENT_STATUSES,
+} from "../../constants/constant_values.js";
 
 const NON_REVENUE_ORDER_STATUSES = [
   ORDER_STATUSES.CANCELLED,
@@ -13,10 +16,18 @@ export async function getDashboardRevenueService() {
     const summary = await Order.find({
       status: { $nin: NON_REVENUE_ORDER_STATUSES },
     })
-      .select("totalAmount updatedAt")
+      .populate({
+        path: "payment",
+        select: { paidAt: 1, status: 1 },
+        match: { status: PAYMENT_STATUSES.PAID },
+      })
+      .select("totalAmount")
       .lean();
+
+    const paidSummary = summary.filter((order) => order.payment);
+
     return {
-      summary,
+      summary: paidSummary,
       totalRevenue: revenueSummary.totalRevenue,
       thisYearRevenue: revenueSummary.thisYearRevenue,
       lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,
@@ -52,15 +63,27 @@ const getRevenueSummaryService = async () => {
     // Start date for "last 6 months" window.
     const sixMonthsAgo = new Date(now);
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
-
     // One query, multiple buckets: total, this year, last 6 months, and today.
     const [summary] = await Order.aggregate([
+      // Join payment docs so filters can use payment status and paidAt.
+      {
+        $lookup: {
+          from: "payments",
+          localField: "payment",
+          foreignField: "_id",
+          as: "payment",
+        },
+      },
+      {
+        $unwind: "$payment",
+      },
       // Ignore non-revenue order statuses before doing any calculations.
       {
         $match: {
           status: {
             $nin: NON_REVENUE_ORDER_STATUSES,
           },
+          "payment.status": PAYMENT_STATUSES.PAID,
         },
       },
       // Compute multiple totals in parallel from the same filtered dataset.
@@ -79,7 +102,7 @@ const getRevenueSummaryService = async () => {
             // Keep only orders created from the start of this year.
             {
               $match: {
-                createdAt: { $gte: startOfYear },
+                "payment.paidAt": { $gte: startOfYear },
               },
             },
             // Sum this year's order amounts.
@@ -94,7 +117,7 @@ const getRevenueSummaryService = async () => {
             // Keep only orders created in the last 6 months.
             {
               $match: {
-                createdAt: { $gte: sixMonthsAgo },
+                "payment.paidAt": { $gte: sixMonthsAgo },
               },
             },
             // Sum order amounts for the 6-month window.
@@ -109,7 +132,7 @@ const getRevenueSummaryService = async () => {
             // Keep only orders created today.
             {
               $match: {
-                createdAt: {
+                "payment.paidAt": {
                   $gte: startOfToday,
                   $lt: endOfToday,
                 },

--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -13,21 +13,50 @@ const NON_REVENUE_ORDER_STATUSES = [
 export async function getDashboardRevenueService() {
   try {
     const revenueSummary = await getRevenueSummaryService();
-    const summary = await Order.find({
-      status: { $nin: NON_REVENUE_ORDER_STATUSES },
-    })
-      .populate({
-        path: "payment",
-        select: { paidAt: 1, status: 1 },
-        match: { status: PAYMENT_STATUSES.PAID },
-      })
-      .select("totalAmount")
-      .lean();
-
-    const paidSummary = summary.filter((order) => order.payment);
+    const summary = await Order.aggregate([
+      {
+        $match: {
+          status: { $nin: NON_REVENUE_ORDER_STATUSES },
+        },
+      },
+      {
+        $lookup: {
+          from: "payments",
+          let: { paymentId: "$payment" },
+          pipeline: [
+            {
+              $match: {
+                $expr: { $eq: ["$_id", "$$paymentId"] },
+              },
+            },
+            {
+              $match: {
+                status: PAYMENT_STATUSES.PAID,
+              },
+            },
+            {
+              $project: {
+                paidAt: 1,
+                status: 1,
+              },
+            },
+          ],
+          as: "payment",
+        },
+      },
+      {
+        $unwind: "$payment",
+      },
+      {
+        $project: {
+          totalAmount: 1,
+          payment: 1,
+        },
+      },
+    ]);
 
     return {
-      summary: paidSummary,
+      summary,
       totalRevenue: revenueSummary.totalRevenue,
       thisYearRevenue: revenueSummary.thisYearRevenue,
       lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -16,7 +16,9 @@ export const dashboardRevenue = (revenue) => ({
 
 export const revenueChartData = (data) => {
   return data?.map((item) => ({
-    date: item?.updatedAt,
+    date: item?.payment?.paidAt
+      ? new Date(item.payment.paidAt).toLocaleDateString()
+      : "",
     data1: item?.totalAmount || 0,
   }));
 };


### PR DESCRIPTION
## Summary
This resolves issue #40 where revenue chart and cards are in sync with updatedAt which can cause inaccurate revenue visualization/data

### Changes
- updated updatedAt to payment.paidAt for data consistency and accuracy
- updated query to filter data with payment.status === PAYMENT_STATUSES.PAID making use of constant_values

### Testing
- login as customer, order something, proceed to payment, check chart for changes (will not show since payment is still pending), pay, check chart again, expected result should be new data shown in chart and card(Today)