### PR TITLE
feat(dashboard): implement revenue summary helper function for dashbo…

### DIFF
--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -3,6 +3,7 @@ import {
   ORDER_STATUSES,
   PAYMENT_STATUSES,
 } from "../../constants/constant_values.js";
+import { getRevenueSummaryService } from "../../utis/dashboardDataHelper.js";
 
 const NON_REVENUE_ORDER_STATUSES = [
   ORDER_STATUSES.CANCELLED,
@@ -12,7 +13,6 @@ const NON_REVENUE_ORDER_STATUSES = [
 
 export async function getDashboardRevenueService() {
   try {
-    const revenueSummary = await getRevenueSummaryService();
     const summary = await Order.aggregate([
       {
         $match: {
@@ -54,6 +54,7 @@ export async function getDashboardRevenueService() {
         },
       },
     ]);
+    const revenueSummary = await getRevenueSummaryService(summary);
 
     return {
       summary,
@@ -66,127 +67,3 @@ export async function getDashboardRevenueService() {
     throw new Error(error.message || "Failed to fetch dashboard revenue");
   }
 }
-
-const getRevenueSummaryService = async () => {
-  try {
-    // Build the current date once to keep all time filters consistent.
-    const now = new Date();
-
-    // Start of the current year (Jan 1, 00:00:00.000).
-    const startOfYear = new Date(now.getFullYear(), 0, 1);
-
-    // Start of today in local server time.
-    const startOfToday = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate(),
-    );
-
-    // End of today in local server time.
-    const endOfToday = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate() + 1,
-    );
-
-    // Start date for "last 6 months" window.
-    const sixMonthsAgo = new Date(now);
-    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
-    // One query, multiple buckets: total, this year, last 6 months, and today.
-    const [summary] = await Order.aggregate([
-      // Join payment docs so filters can use payment status and paidAt.
-      {
-        $lookup: {
-          from: "payments",
-          localField: "payment",
-          foreignField: "_id",
-          as: "payment",
-        },
-      },
-      {
-        $unwind: "$payment",
-      },
-      // Ignore non-revenue order statuses before doing any calculations.
-      {
-        $match: {
-          status: {
-            $nin: NON_REVENUE_ORDER_STATUSES,
-          },
-          "payment.status": PAYMENT_STATUSES.PAID,
-        },
-      },
-      // Compute multiple totals in parallel from the same filtered dataset.
-      {
-        $facet: {
-          total: [
-            // Sum all valid order amounts.
-            {
-              $group: {
-                _id: null,
-                amount: { $sum: "$totalAmount" },
-              },
-            },
-          ],
-          thisYear: [
-            // Keep only orders created from the start of this year.
-            {
-              $match: {
-                "payment.paidAt": { $gte: startOfYear },
-              },
-            },
-            // Sum this year's order amounts.
-            {
-              $group: {
-                _id: null,
-                amount: { $sum: "$totalAmount" },
-              },
-            },
-          ],
-          lastSixMonths: [
-            // Keep only orders created in the last 6 months.
-            {
-              $match: {
-                "payment.paidAt": { $gte: sixMonthsAgo },
-              },
-            },
-            // Sum order amounts for the 6-month window.
-            {
-              $group: {
-                _id: null,
-                amount: { $sum: "$totalAmount" },
-              },
-            },
-          ],
-          today: [
-            // Keep only orders created today.
-            {
-              $match: {
-                "payment.paidAt": {
-                  $gte: startOfToday,
-                  $lt: endOfToday,
-                },
-              },
-            },
-            // Sum today's order amounts.
-            {
-              $group: {
-                _id: null,
-                amount: { $sum: "$totalAmount" },
-              },
-            },
-          ],
-        },
-      },
-    ]);
-
-    // Return numeric totals with safe fallbacks when no documents match.
-    return {
-      totalRevenue: summary?.total?.[0]?.amount || 0,
-      thisYearRevenue: summary?.thisYear?.[0]?.amount || 0,
-      lastSixMonthsRevenue: summary?.lastSixMonths?.[0]?.amount || 0,
-      todayRevenue: summary?.today?.[0]?.amount || 0,
-    };
-  } catch (error) {
-    throw new Error(error.message || "Failed to fetch revenue summary");
-  }
-};

--- a/backend/src/utis/dashboardDataHelper.js
+++ b/backend/src/utis/dashboardDataHelper.js
@@ -1,0 +1,75 @@
+// THIS CONTAINS ALL THE HELPER FUNCTIONS FOR THE DASHBOARD SUMMARY
+
+const roundToTwoDecimals = (value) => Number(value.toFixed(2));
+
+export const getRevenueSummaryService = async (orders = []) => {
+  try {
+    // Build the current date once to keep all time filters consistent.
+    const now = new Date();
+
+    // Start of the current year (Jan 1, 00:00:00.000).
+    const startOfYear = new Date(now.getFullYear(), 0, 1);
+
+    // Start of today in local server time.
+    const startOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+
+    // End of today in local server time.
+    const endOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() + 1,
+    );
+
+    // Start date for "last 6 months" window.
+    const sixMonthsAgo = new Date(now);
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+    
+    const summary = orders.reduce(
+      (accumulator, currentOrder) => {
+        const orderAmount = Number(currentOrder?.totalAmount) || 0;
+        const paidAt = currentOrder?.payment?.paidAt
+          ? new Date(currentOrder.payment.paidAt)
+          : null;
+
+        accumulator.totalRevenue += orderAmount;
+
+        if (!paidAt || Number.isNaN(paidAt.getTime())) {
+          return accumulator;
+        }
+
+        if (paidAt >= startOfYear) {
+          accumulator.thisYearRevenue += orderAmount;
+        }
+
+        if (paidAt >= sixMonthsAgo) {
+          accumulator.lastSixMonthsRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfToday && paidAt < endOfToday) {
+          accumulator.todayRevenue += orderAmount;
+        }
+
+        return accumulator;
+      },
+      {
+        totalRevenue: 0,
+        thisYearRevenue: 0,
+        lastSixMonthsRevenue: 0,
+        todayRevenue: 0,
+      },
+    );
+
+    return {
+      totalRevenue: roundToTwoDecimals(summary.totalRevenue),
+      thisYearRevenue: roundToTwoDecimals(summary.thisYearRevenue),
+      lastSixMonthsRevenue: roundToTwoDecimals(summary.lastSixMonthsRevenue),
+      todayRevenue: roundToTwoDecimals(summary.todayRevenue),
+    };
+  } catch (error) {
+    throw new Error(error.message || "Failed to fetch revenue summary");
+  }
+};


### PR DESCRIPTION
## Summary
this pr adds helper to manage summary dates for revenue data, this can also be used by other sections

### Changes
- getDashboardRevenueService now passes aggregated Order summary to getRevenueSummaryService, this keeps service layer clean and readable
- refactored getRevenueSummaryService to use passed summary to summarize revenue dates
- getRevenueSummaryService automatically rounds revenue to 2 decimal places

### Testing
- no visual/data changes should occur