### PR TITLE
feat(admin-dashboard): add revenue rates UI display

### DIFF
--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -64,8 +64,15 @@ export async function getDashboardRevenueService() {
       summary,
       totalRevenue: revenueSummary.totalRevenue,
       thisYearRevenue: revenueSummary.thisYearRevenue,
+      lastYearRevenue: revenueSummary.lastYearRevenue,
       lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,
+      thisMonthRevenue: revenueSummary.thisMonthRevenue,
+      lastMonthRevenue: revenueSummary.lastMonthRevenue,
+      thisWeekRevenue: revenueSummary.thisWeekRevenue,
+      lastWeekRevenue: revenueSummary.lastWeekRevenue,
       todayRevenue: revenueSummary.todayRevenue,
+      yesterdayRevenue: revenueSummary.yesterdayRevenue,
+      comparisons: revenueSummary.comparisons,
     };
   } catch (error) {
     throw new Error(error.message || "Failed to fetch dashboard revenue");

--- a/backend/src/services/analytics/admin_dashboard_services.js
+++ b/backend/src/services/analytics/admin_dashboard_services.js
@@ -65,6 +65,7 @@ export async function getDashboardRevenueService() {
       totalRevenue: revenueSummary.totalRevenue,
       thisYearRevenue: revenueSummary.thisYearRevenue,
       lastYearRevenue: revenueSummary.lastYearRevenue,
+      thisSixMonthsRevenue: revenueSummary.thisSixMonthsRevenue,
       lastSixMonthsRevenue: revenueSummary.lastSixMonthsRevenue,
       thisMonthRevenue: revenueSummary.thisMonthRevenue,
       lastMonthRevenue: revenueSummary.lastMonthRevenue,

--- a/backend/src/utis/dashboardDataHelper.js
+++ b/backend/src/utis/dashboardDataHelper.js
@@ -94,9 +94,12 @@ export const getRevenueSummaryService = async (orders = []) => {
     const startOfLastYear = new Date(now.getFullYear() - 1, 0, 1);
     const endOfLastYear = startOfYear;
 
-    // Start date for "last 6 months" window.
-    const sixMonthsAgo = new Date(now);
-    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+    // Current and previous 6-month boundaries.
+    const startOfThisSixMonths = new Date(now);
+    startOfThisSixMonths.setMonth(startOfThisSixMonths.getMonth() - 6);
+    const startOfLastSixMonths = new Date(startOfThisSixMonths);
+    startOfLastSixMonths.setMonth(startOfLastSixMonths.getMonth() - 6);
+    const endOfLastSixMonths = startOfThisSixMonths;
 
     const summary = orders.reduce(
       (accumulator, currentOrder) => {
@@ -119,7 +122,11 @@ export const getRevenueSummaryService = async (orders = []) => {
           accumulator.lastYearRevenue += orderAmount;
         }
 
-        if (paidAt >= sixMonthsAgo) {
+        if (paidAt >= startOfThisSixMonths) {
+          accumulator.thisSixMonthsRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfLastSixMonths && paidAt < endOfLastSixMonths) {
           accumulator.lastSixMonthsRevenue += orderAmount;
         }
 
@@ -153,6 +160,7 @@ export const getRevenueSummaryService = async (orders = []) => {
         totalRevenue: 0,
         thisYearRevenue: 0,
         lastYearRevenue: 0,
+        thisSixMonthsRevenue: 0,
         lastSixMonthsRevenue: 0,
         todayRevenue: 0,
         yesterdayRevenue: 0,
@@ -170,6 +178,10 @@ export const getRevenueSummaryService = async (orders = []) => {
         summary.thisMonthRevenue,
         summary.lastMonthRevenue,
       ),
+      sixMonths: getTrendFromPeriods(
+        summary.thisSixMonthsRevenue,
+        summary.lastSixMonthsRevenue,
+      ),
       year: getTrendFromPeriods(summary.thisYearRevenue, summary.lastYearRevenue),
     };
 
@@ -177,6 +189,7 @@ export const getRevenueSummaryService = async (orders = []) => {
       totalRevenue: roundToTwoDecimals(summary.totalRevenue),
       thisYearRevenue: roundToTwoDecimals(summary.thisYearRevenue),
       lastYearRevenue: roundToTwoDecimals(summary.lastYearRevenue),
+      thisSixMonthsRevenue: roundToTwoDecimals(summary.thisSixMonthsRevenue),
       lastSixMonthsRevenue: roundToTwoDecimals(summary.lastSixMonthsRevenue),
       thisMonthRevenue: roundToTwoDecimals(summary.thisMonthRevenue),
       lastMonthRevenue: roundToTwoDecimals(summary.lastMonthRevenue),

--- a/backend/src/utis/dashboardDataHelper.js
+++ b/backend/src/utis/dashboardDataHelper.js
@@ -2,6 +2,53 @@
 
 const roundToTwoDecimals = (value) => Number(value.toFixed(2));
 
+const getTrendFromPeriods = (currentValue = 0, previousValue = 0) => {
+  // Avoid divide-by-zero while still surfacing direction for empty previous periods.
+  if (previousValue === 0) {
+    if (currentValue === 0) {
+      return {
+        currentValue: 0,
+        previousValue: 0,
+        changeAmount: 0,
+        changeRate: 0,
+        direction: "flat",
+      };
+    }
+
+    return {
+      currentValue: roundToTwoDecimals(currentValue),
+      previousValue: 0,
+      changeAmount: roundToTwoDecimals(currentValue),
+      changeRate: 100,
+      direction: "up",
+    };
+  }
+
+  const delta = currentValue - previousValue;
+  const rate = (delta / previousValue) * 100;
+
+  return {
+    currentValue: roundToTwoDecimals(currentValue),
+    previousValue: roundToTwoDecimals(previousValue),
+    changeAmount: roundToTwoDecimals(delta),
+    changeRate: roundToTwoDecimals(Math.abs(rate)),
+    direction: delta > 0 ? "up" : delta < 0 ? "down" : "flat",
+  };
+};
+
+const getStartOfWeek = (date) => {
+  // Use Monday as first day of week for admin reporting.
+  const startOfDay = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  );
+  const day = startOfDay.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  startOfDay.setDate(startOfDay.getDate() + diff);
+  return startOfDay;
+};
+
 export const getRevenueSummaryService = async (orders = []) => {
   try {
     // Build the current date once to keep all time filters consistent.
@@ -24,6 +71,29 @@ export const getRevenueSummaryService = async (orders = []) => {
       now.getDate() + 1,
     );
 
+    // Previous day boundaries.
+    const startOfYesterday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - 1,
+    );
+    const endOfYesterday = startOfToday;
+
+    // Current and previous week boundaries.
+    const startOfThisWeek = getStartOfWeek(now);
+    const startOfLastWeek = new Date(startOfThisWeek);
+    startOfLastWeek.setDate(startOfLastWeek.getDate() - 7);
+    const endOfLastWeek = startOfThisWeek;
+
+    // Current and previous month boundaries.
+    const startOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const startOfLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const endOfLastMonth = startOfThisMonth;
+
+    // Current and previous year boundaries.
+    const startOfLastYear = new Date(now.getFullYear() - 1, 0, 1);
+    const endOfLastYear = startOfYear;
+
     // Start date for "last 6 months" window.
     const sixMonthsAgo = new Date(now);
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
@@ -45,6 +115,10 @@ export const getRevenueSummaryService = async (orders = []) => {
           accumulator.thisYearRevenue += orderAmount;
         }
 
+        if (paidAt >= startOfLastYear && paidAt < endOfLastYear) {
+          accumulator.lastYearRevenue += orderAmount;
+        }
+
         if (paidAt >= sixMonthsAgo) {
           accumulator.lastSixMonthsRevenue += orderAmount;
         }
@@ -53,21 +127,64 @@ export const getRevenueSummaryService = async (orders = []) => {
           accumulator.todayRevenue += orderAmount;
         }
 
+        if (paidAt >= startOfYesterday && paidAt < endOfYesterday) {
+          accumulator.yesterdayRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfThisWeek) {
+          accumulator.thisWeekRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfLastWeek && paidAt < endOfLastWeek) {
+          accumulator.lastWeekRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfThisMonth) {
+          accumulator.thisMonthRevenue += orderAmount;
+        }
+
+        if (paidAt >= startOfLastMonth && paidAt < endOfLastMonth) {
+          accumulator.lastMonthRevenue += orderAmount;
+        }
+
         return accumulator;
       },
       {
         totalRevenue: 0,
         thisYearRevenue: 0,
+        lastYearRevenue: 0,
         lastSixMonthsRevenue: 0,
         todayRevenue: 0,
+        yesterdayRevenue: 0,
+        thisWeekRevenue: 0,
+        lastWeekRevenue: 0,
+        thisMonthRevenue: 0,
+        lastMonthRevenue: 0,
       },
     );
+
+    const comparisons = {
+      day: getTrendFromPeriods(summary.todayRevenue, summary.yesterdayRevenue),
+      week: getTrendFromPeriods(summary.thisWeekRevenue, summary.lastWeekRevenue),
+      month: getTrendFromPeriods(
+        summary.thisMonthRevenue,
+        summary.lastMonthRevenue,
+      ),
+      year: getTrendFromPeriods(summary.thisYearRevenue, summary.lastYearRevenue),
+    };
 
     return {
       totalRevenue: roundToTwoDecimals(summary.totalRevenue),
       thisYearRevenue: roundToTwoDecimals(summary.thisYearRevenue),
+      lastYearRevenue: roundToTwoDecimals(summary.lastYearRevenue),
       lastSixMonthsRevenue: roundToTwoDecimals(summary.lastSixMonthsRevenue),
+      thisMonthRevenue: roundToTwoDecimals(summary.thisMonthRevenue),
+      lastMonthRevenue: roundToTwoDecimals(summary.lastMonthRevenue),
+      thisWeekRevenue: roundToTwoDecimals(summary.thisWeekRevenue),
+      lastWeekRevenue: roundToTwoDecimals(summary.lastWeekRevenue),
       todayRevenue: roundToTwoDecimals(summary.todayRevenue),
+      yesterdayRevenue: roundToTwoDecimals(summary.yesterdayRevenue),
+      comparisons,
     };
   } catch (error) {
     throw new Error(error.message || "Failed to fetch revenue summary");

--- a/frontend/src/features/admin/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboard.jsx
@@ -34,7 +34,10 @@ const AdminDashboard = () => {
         <div className="@container/main flex flex-1 flex-col gap-2">
           <div className="flex flex-col gap-4 md:gap-6">
             <TabsContent value="revenue" className="space-y-6 overflow-auto">
-              <DashboardCards data={dashboardRevenue(revenue)} />
+              <DashboardCards
+                data={dashboardRevenue(revenue)}
+                metricName="Revenue"
+              />
               <div className="px-4 lg:px-6">
                 <DashboardCharts
                   chartData={revenueChartData(revenue?.revenue?.summary)}
@@ -44,7 +47,10 @@ const AdminDashboard = () => {
               </div>
             </TabsContent>
             <TabsContent value="customers" className="space-y-6">
-              <DashboardCards data={dashboardCustomerSummary(customers)} />
+              <DashboardCards
+                data={dashboardCustomerSummary(customers)}
+                metricName="Visitors"
+              />
               <div className="px-4 lg:px-6">
                 <DashboardCharts
                   chartData={getCustomerSummaryChartData(
@@ -56,7 +62,10 @@ const AdminDashboard = () => {
               </div>
             </TabsContent>
             <TabsContent value="performance" className="space-y-6">
-              <DashboardCards data={dashboardPerformaceSummary(performance)} />
+              <DashboardCards
+                data={dashboardPerformaceSummary(performance)}
+                metricName="Orders"
+              />
               <div className="px-4 lg:px-6">
                 <DashboardCharts
                   chartData={getPerformanceSummaryChartData(

--- a/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
@@ -7,7 +7,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { TrendingDown, TrendingUp } from "lucide-react";
+import { Minus, TrendingDown, TrendingUp } from "lucide-react";
+
+const badgeClassByType = {
+  negative: "bg-[var(--color-negative-light)] text-destructive",
+  neutral: "bg-muted text-muted-foreground",
+  positive: "bg-[var(--color-positive-light)] text-[var(--color-positive)]",
+};
+
 const DashboardCards = ({ data }) => {
   return (
     <div className="grid grid-cols-1 gap-4 px-4 lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
@@ -24,9 +31,13 @@ const DashboardCards = ({ data }) => {
               <CardAction>
                 <Badge
                   variant="secondary"
-                  className={`${card.type === "negative" ? "bg-[var(--color-negative-light)] text-destructive" : "bg-[var(--color-positive-light)] text-[var(--color-positive)]"}`}>
+                  className={
+                    badgeClassByType[card.type] || badgeClassByType.positive
+                  }>
                   {card.type === "negative" ? (
                     <TrendingDown className="size-4" />
+                  ) : card.type === "neutral" ? (
+                    <Minus className="size-4" />
                   ) : (
                     <TrendingUp className="size-4" />
                   )}
@@ -35,16 +46,14 @@ const DashboardCards = ({ data }) => {
               </CardAction>
             )}
           </CardHeader>
-          {/* 
-          "bg-[var(--color-positive-light)] text-[var(--color-positive)]">
-          <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Trending up this month <TrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Visitors for the last 6 months
-          </div>
-        </CardFooter> */}
+          {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
+            <div className="line-clamp-1 flex gap-2 font-medium">
+              Trending up this month <TrendingUp className="size-4" />
+            </div>
+            <div className="text-muted-foreground">
+              Visitors for the last 6 months
+            </div>
+          </CardFooter> */}
         </Card>
       ))}
     </div>

--- a/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
@@ -15,7 +15,31 @@ const badgeClassByType = {
   positive: "bg-[var(--color-positive-light)] text-[var(--color-positive)]",
 };
 
-const DashboardCards = ({ data }) => {
+const getFooterTitle = (cardLabel = "", metricName = "Metric") => {
+  // Build a readable footer line from common dashboard period labels.
+  if (cardLabel.includes("Today")) {
+    return `${metricName} today`;
+  }
+  if (cardLabel.includes("This Week")) {
+    return `${metricName} this week`;
+  }
+  if (cardLabel.includes("This Month")) {
+    return `${metricName} this month`;
+  }
+  if (cardLabel.includes("This Year")) {
+    return `${metricName} this year`;
+  }
+  if (cardLabel.includes("Last 6 Months")) {
+    return `${metricName} in the last 6 months`;
+  }
+  if (cardLabel.toLowerCase().includes("total")) {
+    return `Total ${metricName.toLowerCase()} snapshot`;
+  }
+
+  return `${metricName} overview`;
+};
+
+const DashboardCards = ({ data, metricName = "Metric" }) => {
   return (
     <div className="grid grid-cols-1 gap-4 px-4 lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
       {data?.map((card) => (
@@ -46,14 +70,23 @@ const DashboardCards = ({ data }) => {
               </CardAction>
             )}
           </CardHeader>
-          {/* <CardFooter className="flex-col items-start gap-1.5 text-sm">
+          <CardFooter className="flex-col items-start gap-1.5 text-sm">
             <div className="line-clamp-1 flex gap-2 font-medium">
-              Trending up this month <TrendingUp className="size-4" />
+              {card.footerTitle || getFooterTitle(card.label, metricName)}
+              {card.type === "negative" ? (
+                <TrendingDown className="size-4" />
+              ) : card.type === "neutral" ? (
+                <Minus className="size-4" />
+              ) : (
+                <TrendingUp className="size-4" />
+              )}
             </div>
-            <div className="text-muted-foreground">
-              Visitors for the last 6 months
-            </div>
-          </CardFooter> */}
+            {card.comparisonText && (
+              <div className="text-muted-foreground">
+                {metricName} is {card.comparisonText}
+              </div>
+            )}
+          </CardFooter>
         </Card>
       ))}
     </div>

--- a/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
+++ b/frontend/src/features/admin/dashboard/components/DashboardCards.jsx
@@ -15,6 +15,36 @@ const badgeClassByType = {
   positive: "bg-[var(--color-positive-light)] text-[var(--color-positive)]",
 };
 
+const highlightPercentage = (text, type) => {
+  // Parse comparison text and highlight only the percentage value.
+  const percentPattern = /(\d+\.?\d*)%/;
+  const match = text.match(percentPattern);
+
+  if (!match) {
+    return text;
+  }
+
+  const [fullMatch, percentValue] = match;
+  const beforePercent = text.substring(0, match.index);
+  const afterPercent = text.substring(match.index + fullMatch.length);
+
+  const percentHighlightColor = {
+    negative: "text-destructive font-bold",
+    neutral: "text-muted-foreground font-bold",
+    positive: "text-[var(--color-positive)] font-bold",
+  };
+
+  return (
+    <>
+      {beforePercent}
+      <span className={percentHighlightColor[type] || percentHighlightColor.positive}>
+        {percentValue}%
+      </span>
+      {afterPercent}
+    </>
+  );
+};
+
 const getFooterTitle = (cardLabel = "", metricName = "Metric") => {
   // Build a readable footer line from common dashboard period labels.
   if (cardLabel.includes("Today")) {
@@ -83,7 +113,7 @@ const DashboardCards = ({ data, metricName = "Metric" }) => {
             </div>
             {card.comparisonText && (
               <div className="text-muted-foreground">
-                {metricName} is {card.comparisonText}
+                {metricName} is {highlightPercentage(card.comparisonText, card.type)}
               </div>
             )}
           </CardFooter>

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -65,8 +65,12 @@ export const dashboardRevenue = (revenue) => [
     ),
   },
   {
-    label: "Last 6 Months",
-    value: `₱${revenue?.revenue?.lastSixMonthsRevenue?.toLocaleString() || 0}`,
+    label: "This 6 Months",
+    value: `₱${revenue?.revenue?.thisSixMonthsRevenue?.toLocaleString() || 0}`,
+    rate: revenue?.revenue?.comparisons?.sixMonths?.changeRate || 0,
+    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.sixMonths?.direction),
+    comparisonPeriod: "prior 6 months",
+    comparisonText: getComparisonText(revenue?.revenue?.comparisons?.sixMonths?.direction, revenue?.revenue?.comparisons?.sixMonths?.changeRate || 0, "the prior 6 months", revenue?.revenue?.comparisons?.sixMonths?.currentValue, revenue?.revenue?.comparisons?.sixMonths?.previousValue, true),
   },
   {
     label: "This Month",

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -10,13 +10,36 @@ const mapTrendDirectionToType = (direction) => {
   return "positive";
 };
 
-const getComparisonText = (direction, changeRate, comparisonPeriod) => {
+const formatValue = (value, isRevenue = false) => {
+  // Format a numeric value with locale support and optional currency prefix.
+  const formattedNum = Number(value)?.toLocaleString() || 0;
+  return isRevenue ? `₱${formattedNum}` : formattedNum;
+};
+
+const getComparisonText = (
+  direction,
+  changeRate,
+  comparisonPeriod,
+  currentValue,
+  previousValue,
+  isRevenue = false,
+) => {
+  // Build comparison text with both current and previous period values.
   if (direction === "flat") {
     return `Unchanged compared to ${comparisonPeriod}`;
   }
 
   const action = direction === "up" ? "up" : "down";
-  return `${action} ${changeRate.toFixed(1)}% compared to ${comparisonPeriod}`;
+  const trendText = `${action} ${changeRate.toFixed(1)}%`;
+
+  // Include previous period value if available.
+  if (currentValue !== undefined && previousValue !== undefined) {
+    const current = formatValue(currentValue, isRevenue);
+    const previous = formatValue(previousValue, isRevenue);
+    return `${trendText} compared to ${comparisonPeriod} (${previous} → ${current})`;
+  }
+
+  return `${trendText} compared to ${comparisonPeriod}`;
 };
 
 export const dashboardRevenue = (revenue) => [
@@ -36,6 +59,9 @@ export const dashboardRevenue = (revenue) => [
       revenue?.revenue?.comparisons?.year?.direction,
       revenue?.revenue?.comparisons?.year?.changeRate || 0,
       "last year",
+      revenue?.revenue?.comparisons?.year?.currentValue,
+      revenue?.revenue?.comparisons?.year?.previousValue,
+      true,
     ),
   },
   {
@@ -54,6 +80,9 @@ export const dashboardRevenue = (revenue) => [
       revenue?.revenue?.comparisons?.month?.direction,
       revenue?.revenue?.comparisons?.month?.changeRate || 0,
       "last month",
+      revenue?.revenue?.comparisons?.month?.currentValue,
+      revenue?.revenue?.comparisons?.month?.previousValue,
+      true,
     ),
   },
   {
@@ -68,6 +97,9 @@ export const dashboardRevenue = (revenue) => [
       revenue?.revenue?.comparisons?.week?.direction,
       revenue?.revenue?.comparisons?.week?.changeRate || 0,
       "last week",
+      revenue?.revenue?.comparisons?.week?.currentValue,
+      revenue?.revenue?.comparisons?.week?.previousValue,
+      true,
     ),
   },
   {
@@ -82,6 +114,9 @@ export const dashboardRevenue = (revenue) => [
       revenue?.revenue?.comparisons?.day?.direction,
       revenue?.revenue?.comparisons?.day?.changeRate || 0,
       "yesterday",
+      revenue?.revenue?.comparisons?.day?.currentValue,
+      revenue?.revenue?.comparisons?.day?.previousValue,
+      true,
     ),
   },
 ];

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -1,3 +1,15 @@
+const mapTrendDirectionToType = (direction) => {
+  if (direction === "down") {
+    return "negative";
+  }
+
+  if (direction === "flat") {
+    return "neutral";
+  }
+
+  return "positive";
+};
+
 export const dashboardRevenue = (revenue) => [
   {
     label: "Total Revenue",
@@ -6,14 +18,32 @@ export const dashboardRevenue = (revenue) => [
   {
     label: "This Year",
     value: `₱${revenue?.revenue?.thisYearRevenue?.toLocaleString() || 0}`,
+    rate: revenue?.revenue?.comparisons?.year?.changeRate || 0,
+    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.year?.direction),
   },
   {
-    label: "Last 6 Months",
-    value: `₱${revenue?.revenue?.lastSixMonthsRevenue?.toLocaleString() || 0}`,
+    label: "This Month",
+    value: `₱${revenue?.revenue?.thisMonthRevenue?.toLocaleString() || 0}`,
+    rate: revenue?.revenue?.comparisons?.month?.changeRate || 0,
+    type: mapTrendDirectionToType(
+      revenue?.revenue?.comparisons?.month?.direction,
+    ),
+  },
+  {
+    label: "This Week",
+    value: `₱${revenue?.revenue?.thisWeekRevenue?.toLocaleString() || 0}`,
+    rate: revenue?.revenue?.comparisons?.week?.changeRate || 0,
+    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.week?.direction),
   },
   {
     label: "Today",
     value: `₱${revenue?.revenue?.todayRevenue?.toLocaleString() || 0}`,
+    rate: revenue?.revenue?.comparisons?.day?.changeRate || 0,
+    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.day?.direction),
+  },
+  {
+    label: "Last 6 Months",
+    value: `₱${revenue?.revenue?.lastSixMonthsRevenue?.toLocaleString() || 0}`,
   },
 ];
 

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -10,6 +10,15 @@ const mapTrendDirectionToType = (direction) => {
   return "positive";
 };
 
+const getComparisonText = (direction, changeRate, comparisonPeriod) => {
+  if (direction === "flat") {
+    return `Unchanged compared to ${comparisonPeriod}`;
+  }
+
+  const action = direction === "up" ? "up" : "down";
+  return `${action} ${changeRate.toFixed(1)}% compared to ${comparisonPeriod}`;
+};
+
 export const dashboardRevenue = (revenue) => [
   {
     label: "Total Revenue",
@@ -19,7 +28,19 @@ export const dashboardRevenue = (revenue) => [
     label: "This Year",
     value: `₱${revenue?.revenue?.thisYearRevenue?.toLocaleString() || 0}`,
     rate: revenue?.revenue?.comparisons?.year?.changeRate || 0,
-    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.year?.direction),
+    type: mapTrendDirectionToType(
+      revenue?.revenue?.comparisons?.year?.direction,
+    ),
+    comparisonPeriod: "last year",
+    comparisonText: getComparisonText(
+      revenue?.revenue?.comparisons?.year?.direction,
+      revenue?.revenue?.comparisons?.year?.changeRate || 0,
+      "last year",
+    ),
+  },
+  {
+    label: "Last 6 Months",
+    value: `₱${revenue?.revenue?.lastSixMonthsRevenue?.toLocaleString() || 0}`,
   },
   {
     label: "This Month",
@@ -28,22 +49,40 @@ export const dashboardRevenue = (revenue) => [
     type: mapTrendDirectionToType(
       revenue?.revenue?.comparisons?.month?.direction,
     ),
+    comparisonPeriod: "last month",
+    comparisonText: getComparisonText(
+      revenue?.revenue?.comparisons?.month?.direction,
+      revenue?.revenue?.comparisons?.month?.changeRate || 0,
+      "last month",
+    ),
   },
   {
     label: "This Week",
     value: `₱${revenue?.revenue?.thisWeekRevenue?.toLocaleString() || 0}`,
     rate: revenue?.revenue?.comparisons?.week?.changeRate || 0,
-    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.week?.direction),
+    type: mapTrendDirectionToType(
+      revenue?.revenue?.comparisons?.week?.direction,
+    ),
+    comparisonPeriod: "last week",
+    comparisonText: getComparisonText(
+      revenue?.revenue?.comparisons?.week?.direction,
+      revenue?.revenue?.comparisons?.week?.changeRate || 0,
+      "last week",
+    ),
   },
   {
     label: "Today",
     value: `₱${revenue?.revenue?.todayRevenue?.toLocaleString() || 0}`,
     rate: revenue?.revenue?.comparisons?.day?.changeRate || 0,
-    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.day?.direction),
-  },
-  {
-    label: "Last 6 Months",
-    value: `₱${revenue?.revenue?.lastSixMonthsRevenue?.toLocaleString() || 0}`,
+    type: mapTrendDirectionToType(
+      revenue?.revenue?.comparisons?.day?.direction,
+    ),
+    comparisonPeriod: "yesterday",
+    comparisonText: getComparisonText(
+      revenue?.revenue?.comparisons?.day?.direction,
+      revenue?.revenue?.comparisons?.day?.changeRate || 0,
+      "yesterday",
+    ),
   },
 ];
 

--- a/frontend/src/features/admin/dashboard/util/dashboardStats.js
+++ b/frontend/src/features/admin/dashboard/util/dashboardStats.js
@@ -42,88 +42,92 @@ const getComparisonText = (
   return `${trendText} compared to ${comparisonPeriod}`;
 };
 
-export const dashboardRevenue = (revenue) => [
-  {
-    label: "Total Revenue",
-    value: `₱${revenue?.revenue?.totalRevenue?.toLocaleString() || 0}`,
-  },
-  {
-    label: "This Year",
-    value: `₱${revenue?.revenue?.thisYearRevenue?.toLocaleString() || 0}`,
-    rate: revenue?.revenue?.comparisons?.year?.changeRate || 0,
-    type: mapTrendDirectionToType(
-      revenue?.revenue?.comparisons?.year?.direction,
-    ),
-    comparisonPeriod: "last year",
-    comparisonText: getComparisonText(
-      revenue?.revenue?.comparisons?.year?.direction,
-      revenue?.revenue?.comparisons?.year?.changeRate || 0,
-      "last year",
-      revenue?.revenue?.comparisons?.year?.currentValue,
-      revenue?.revenue?.comparisons?.year?.previousValue,
-      true,
-    ),
-  },
-  {
-    label: "This 6 Months",
-    value: `₱${revenue?.revenue?.thisSixMonthsRevenue?.toLocaleString() || 0}`,
-    rate: revenue?.revenue?.comparisons?.sixMonths?.changeRate || 0,
-    type: mapTrendDirectionToType(revenue?.revenue?.comparisons?.sixMonths?.direction),
-    comparisonPeriod: "prior 6 months",
-    comparisonText: getComparisonText(revenue?.revenue?.comparisons?.sixMonths?.direction, revenue?.revenue?.comparisons?.sixMonths?.changeRate || 0, "the prior 6 months", revenue?.revenue?.comparisons?.sixMonths?.currentValue, revenue?.revenue?.comparisons?.sixMonths?.previousValue, true),
-  },
-  {
-    label: "This Month",
-    value: `₱${revenue?.revenue?.thisMonthRevenue?.toLocaleString() || 0}`,
-    rate: revenue?.revenue?.comparisons?.month?.changeRate || 0,
-    type: mapTrendDirectionToType(
-      revenue?.revenue?.comparisons?.month?.direction,
-    ),
-    comparisonPeriod: "last month",
-    comparisonText: getComparisonText(
-      revenue?.revenue?.comparisons?.month?.direction,
-      revenue?.revenue?.comparisons?.month?.changeRate || 0,
-      "last month",
-      revenue?.revenue?.comparisons?.month?.currentValue,
-      revenue?.revenue?.comparisons?.month?.previousValue,
-      true,
-    ),
-  },
-  {
-    label: "This Week",
-    value: `₱${revenue?.revenue?.thisWeekRevenue?.toLocaleString() || 0}`,
-    rate: revenue?.revenue?.comparisons?.week?.changeRate || 0,
-    type: mapTrendDirectionToType(
-      revenue?.revenue?.comparisons?.week?.direction,
-    ),
-    comparisonPeriod: "last week",
-    comparisonText: getComparisonText(
-      revenue?.revenue?.comparisons?.week?.direction,
-      revenue?.revenue?.comparisons?.week?.changeRate || 0,
-      "last week",
-      revenue?.revenue?.comparisons?.week?.currentValue,
-      revenue?.revenue?.comparisons?.week?.previousValue,
-      true,
-    ),
-  },
-  {
-    label: "Today",
-    value: `₱${revenue?.revenue?.todayRevenue?.toLocaleString() || 0}`,
-    rate: revenue?.revenue?.comparisons?.day?.changeRate || 0,
-    type: mapTrendDirectionToType(
-      revenue?.revenue?.comparisons?.day?.direction,
-    ),
-    comparisonPeriod: "yesterday",
-    comparisonText: getComparisonText(
-      revenue?.revenue?.comparisons?.day?.direction,
-      revenue?.revenue?.comparisons?.day?.changeRate || 0,
-      "yesterday",
-      revenue?.revenue?.comparisons?.day?.currentValue,
-      revenue?.revenue?.comparisons?.day?.previousValue,
-      true,
-    ),
-  },
-];
+export const dashboardRevenue = (revenue) => {
+  const revenueData = revenue?.revenue;
+  return [
+    {
+      label: "Total Revenue",
+      value: `₱${revenueData?.totalRevenue?.toLocaleString() || 0}`,
+    },
+    {
+      label: "This Year",
+      value: `₱${revenueData?.thisYearRevenue?.toLocaleString() || 0}`,
+      rate: revenueData?.comparisons?.year?.changeRate || 0,
+      type: mapTrendDirectionToType(revenueData?.comparisons?.year?.direction),
+      comparisonPeriod: "last year",
+      comparisonText: getComparisonText(
+        revenueData?.comparisons?.year?.direction,
+        revenueData?.comparisons?.year?.changeRate || 0,
+        "last year",
+        revenueData?.comparisons?.year?.currentValue,
+        revenueData?.comparisons?.year?.previousValue,
+        true,
+      ),
+    },
+    {
+      label: "This 6 Months",
+      value: `₱${revenueData?.thisSixMonthsRevenue?.toLocaleString() || 0}`,
+      rate: revenueData?.comparisons?.sixMonths?.changeRate || 0,
+      type: mapTrendDirectionToType(
+        revenueData?.comparisons?.sixMonths?.direction,
+      ),
+      comparisonPeriod: "prior 6 months",
+      comparisonText: getComparisonText(
+        revenueData?.comparisons?.sixMonths?.direction,
+        revenueData?.comparisons?.sixMonths?.changeRate || 0,
+        "the prior 6 months",
+        revenueData?.comparisons?.sixMonths?.currentValue,
+        revenueData?.comparisons?.sixMonths?.previousValue,
+        true,
+      ),
+    },
+    {
+      label: "This Month",
+      value: `₱${revenueData?.thisMonthRevenue?.toLocaleString() || 0}`,
+      rate: revenueData?.comparisons?.month?.changeRate || 0,
+      type: mapTrendDirectionToType(revenueData?.comparisons?.month?.direction),
+      comparisonPeriod: "last month",
+      comparisonText: getComparisonText(
+        revenueData?.comparisons?.month?.direction,
+        revenueData?.comparisons?.month?.changeRate || 0,
+        "last month",
+        revenueData?.comparisons?.month?.currentValue,
+        revenueData?.comparisons?.month?.previousValue,
+        true,
+      ),
+    },
+    {
+      label: "This Week",
+      value: `₱${revenueData?.thisWeekRevenue?.toLocaleString() || 0}`,
+      rate: revenueData?.comparisons?.week?.changeRate || 0,
+      type: mapTrendDirectionToType(revenueData?.comparisons?.week?.direction),
+      comparisonPeriod: "last week",
+      comparisonText: getComparisonText(
+        revenueData?.comparisons?.week?.direction,
+        revenueData?.comparisons?.week?.changeRate || 0,
+        "last week",
+        revenueData?.comparisons?.week?.currentValue,
+        revenueData?.comparisons?.week?.previousValue,
+        true,
+      ),
+    },
+    {
+      label: "Today",
+      value: `₱${revenueData?.todayRevenue?.toLocaleString() || 0}`,
+      rate: revenueData?.comparisons?.day?.changeRate || 0,
+      type: mapTrendDirectionToType(revenueData?.comparisons?.day?.direction),
+      comparisonPeriod: "yesterday",
+      comparisonText: getComparisonText(
+        revenueData?.comparisons?.day?.direction,
+        revenueData?.comparisons?.day?.changeRate || 0,
+        "yesterday",
+        revenueData?.comparisons?.day?.currentValue,
+        revenueData?.comparisons?.day?.previousValue,
+        true,
+      ),
+    },
+  ];
+};
 
 export const revenueChartData = (data) => {
   return data?.map((item) => ({


### PR DESCRIPTION
## Summary
This PR enhances the admin dashboard by introducing period-over-period revenue comparisons and percentage change indicators across multiple time ranges.

The goal is to provide clearer visibility into revenue trends by comparing current performance against equivalent previous periods (e.g., today vs yesterday, last 7 days vs previous 7 days, etc.).

### Changes
1. Revenue Comparison Logic
- Implemented dynamic period comparison across:
  - Today vs Yesterday
  - This Week vs Last Week
  - This Month vs Previous Month
  - This 6 Months vs Previous 6 Months
  - This Year vs Previous Year

- Added percentage change calculation:
  - % change = ((current - previous) / previous) * 100
  - Handled edge cases:
  - Prevent division by zero when previous period = 0
  - Graceful fallback for empty datasets

2. Dashboard UI Enhancements
- Added comparison text (e.g., “↑ +12.4% vs last 7 days”)
  - Improved badge styling:
  - Positive → upward trend
  - Negative → downward trend
  - Neutral → no change
- Updated DashboardCards to:
  - Display metric labels more clearly
  - Support dynamic comparison text
3. Revenue Metrics Expansion
- Added 6-month revenue view
- Improved labeling consistency (e.g., “This 6 Months” → aligned naming)
- Enhanced revenue summaries with clearer time-based breakdowns
4. Refactoring
- Refactored dashboardRevenue logic:
- Cleaner structure for time range handling
- Reusable comparison logic
- Improved readability and maintainability
### Note
- This PR focuses on revenue metrics only
- Similar comparison logic can be extended to:
  - Customers (new vs returning trends)
  - Performance metrics (orders, AOV, etc.)